### PR TITLE
Modifications for using with Zephyr

### DIFF
--- a/examples/basic/ArduinoLogoDrawing/ArduinoLogoDrawing.ino
+++ b/examples/basic/ArduinoLogoDrawing/ArduinoLogoDrawing.ino
@@ -7,16 +7,21 @@
   Note: This example is also embedded in the Mbed Core:
   https://github.com/arduino/ArduinoCore-mbed/blob/main/libraries/Arduino_H7_Video/
 */
-
+#ifdef __MBED__
 #include "Arduino_H7_Video.h"
 #include "ArduinoGraphics.h"
-
 Arduino_H7_Video Display(800, 480, GigaDisplayShield);
 //Arduino_H7_Video Display(1024, 768, USBCVideo);
+#elif defined(__ZEPHYR__)
+#include "Arduino_GigaDisplay.h"
+#include "ArduinoGraphics.h"
+Display Display(800, 480);
+#endif
 
 void setup() {
+  while(!Serial && millis() < 5000);
   Display.begin();
-  
+
   Display.beginDraw();
   Display.background(255, 255, 255);
   Display.clear();

--- a/examples/basic/SimpleText/SimpleText.ino
+++ b/examples/basic/SimpleText/SimpleText.ino
@@ -15,10 +15,16 @@
   This example code is in the public domain.
 */
 
+#ifdef __MBED__
 #include "Arduino_H7_Video.h"
 #include "ArduinoGraphics.h"
-
 Arduino_H7_Video Display(800, 480, GigaDisplayShield);
+//Arduino_H7_Video Display(1024, 768, USBCVideo);
+#elif defined(__ZEPHYR__)
+#include "Arduino_GigaDisplay.h"
+#include "ArduinoGraphics.h"
+Display Display(800, 480);
+#endif
 
 void setup() {
   Display.begin();

--- a/src/Arduino_GigaDisplay.h
+++ b/src/Arduino_GigaDisplay.h
@@ -2,5 +2,7 @@
 #define  _ARDUINO_GIGADISPLAY_H_
 
 #include "GigaDisplayRGB.h"
-
+#ifdef __ZEPHYR__
+#include "GigaDisplay.h"
+#endif
 #endif

--- a/src/GigaDisplay.cpp
+++ b/src/GigaDisplay.cpp
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2025 Arduino SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Camera driver.
+ */
+#ifdef __ZEPHYR__
+
+#include "Arduino.h"
+#include "Arduino_GigaDisplay.h"
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/display.h>
+
+Display::Display() : gdev(NULL){
+
+}
+
+bool Display::begin(DisplayPixelFormat pixformat, int rotation) {
+  
+  int ret = 0;
+
+  #if DT_HAS_CHOSEN(zephyr_display)
+  this->gdev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
+  #endif
+
+  if (!this->gdev || !device_is_ready(this->gdev)) {
+    Serial.println("\t<err> Zephy Display Not Ready!...");
+      return false;
+  }
+
+  // Get capabilities
+  struct display_capabilities capabilities = {0};
+  display_get_capabilities(this->gdev, &capabilities);
+
+  uint8_t format_spec = 0;
+  
+  switch (pixformat) {
+      case DISPLAY_RGB565:
+          //Serial.println("Set RGB565");
+          if (capabilities.current_pixel_format != PIXEL_FORMAT_RGB_565) {
+            ret = display_set_pixel_format(this->gdev, PIXEL_FORMAT_RGB_565);
+          }
+          format_spec = 1;
+          break;
+      case DISPLAY_RGB888:
+          //Serial.println("Set RGB888");
+          if (capabilities.current_pixel_format != PIXEL_FORMAT_RGB_888) {
+            ret = display_set_pixel_format(this->gdev, PIXEL_FORMAT_RGB_888);
+          }
+          format_spec = 1;
+          break;
+      default:
+          break;
+  }
+
+  if(format_spec == 0) {
+    Serial.println("\t<err> The specified format is not supported");
+    return false;
+  }
+   
+  if (ret) {
+		Serial.println("\t<err> Unable to set display format");
+		return false;
+	}
+  
+
+  display_orientation orientation;
+  switch(rotation){
+    case 0:
+      orientation = DISPLAY_ORIENTATION_NORMAL;
+      break;
+    case 1:
+      orientation = DISPLAY_ORIENTATION_ROTATED_90;
+      break;
+    case 2:
+      orientation = DISPLAY_ORIENTATION_ROTATED_180;
+      break;      
+    case 3:
+      orientation = DISPLAY_ORIENTATION_ROTATED_270;
+      break;
+    default:
+      orientation = DISPLAY_ORIENTATION_NORMAL;
+      break;   
+  }
+  //Rotation not supported
+  //Serial.print("Orientation: "); Serial.println(orientation);
+  ret = display_set_orientation(this->gdev, orientation);
+  Serial.println(ret);
+  if(ret) {
+    Serial.println("\t<err> Failed to set display rotation");
+    //return false;
+  }
+
+  display_get_capabilities(this->gdev, &capabilities);
+
+	printk("- Capabilities:\n");
+	printk("  x_resolution = %u, y_resolution = %u\n, supported_pixel_formats = %u\n"
+	       "  current_pixel_format = %u, current_orientation = %u\n",
+	       capabilities.x_resolution, capabilities.y_resolution,
+	       capabilities.supported_pixel_formats, capabilities.current_pixel_format,
+	       capabilities.current_orientation);
+
+  _height = capabilities.y_resolution;
+  _width = capabilities.x_resolution;
+
+  return true;
+}
+
+int Display::write8(const uint16_t x,
+            const uint16_t y,
+            const void *buf) {
+              
+
+//  printk("Display::write8(%u %u %p) %p %x\n", x, y, buf, 
+//      &((struct display_driver_api *)gdev->api)->write, *((uint32_t*)(&((struct display_driver_api *)gdev->api)->write)));
+
+  return display_write(this->gdev, x, y, this->buf_desc, buf);
+  
+}
+
+void Display::setFrameDesc(uint16_t w, uint16_t h, uint16_t pitch, uint32_t buf_size) {
+	this->buf_desc->buf_size = buf_size;
+	this->buf_desc->width = w;  /** Number of pixels between consecutive rows in the data buffer */
+	this->buf_desc->height = h;  /** Data buffer row width in pixels */
+	this->buf_desc->pitch = pitch;	/** Data buffer row height in pixels */
+    
+}
+
+void Display::startFrameBuffering() {
+
+	this->buf_desc->frame_incomplete = false;
+
+}
+
+void Display::endFrameBuffering() {
+
+	this->buf_desc->frame_incomplete = true;
+
+}
+
+int Display::setBlanking(bool on) {
+  int ret = 0;
+  if(on) {
+    ret = display_blanking_on(this->gdev);
+  } else {
+    ret = display_blanking_off(this->gdev);
+  }
+  if(ret < 0) {
+    return false;
+  }
+  return true;
+}
+
+void* Display::getFrameBuffer() {
+  void* fb  = display_get_framebuffer(this->gdev);
+  return fb;
+}
+
+#endif //__ZEPHYR__

--- a/src/GigaDisplay.cpp
+++ b/src/GigaDisplay.cpp
@@ -88,6 +88,7 @@ bool Display::begin(DisplayPixelFormat pixformat) {
           if (capabilities.current_pixel_format != PIXEL_FORMAT_RGB_565) {
             ret = display_set_pixel_format(this->gdev, PIXEL_FORMAT_RGB_565);
           }
+					printk("RGB565 set\n");
           format_spec = 1;
           break;
       case DISPLAY_RGB888:
@@ -253,32 +254,31 @@ bool Display::begin(DisplayPixelFormat pixformat) {
 int Display::write8(const uint16_t x,
             const uint16_t y,
             const void *buf) {
-              
 
 //  printk("Display::write8(%u %u %p) %p %x\n", x, y, buf, 
 //      &((struct display_driver_api *)gdev->api)->write, *((uint32_t*)(&((struct display_driver_api *)gdev->api)->write)));
 
-  return display_write(this->gdev, x, y, this->buf_desc, buf);
+  return display_write(this->gdev, x, y, &buf_desc, buf);
   
 }
 
 void Display::setFrameDesc(uint16_t w, uint16_t h, uint16_t pitch, uint32_t buf_size) {
-	this->buf_desc->buf_size = buf_size;
-	this->buf_desc->width = w;  /** Number of pixels between consecutive rows in the data buffer */
-	this->buf_desc->height = h;  /** Data buffer row width in pixels */
-	this->buf_desc->pitch = pitch;	/** Data buffer row height in pixels */
+	buf_desc.buf_size = buf_size;
+	buf_desc.width = w;  /** Number of pixels between consecutive rows in the data buffer */
+	buf_desc.height = h;  /** Data buffer row width in pixels */
+	buf_desc.pitch = pitch;	/** Data buffer row height in pixels */
     
 }
 
 void Display::startFrameBuffering() {
 
-	this->buf_desc->frame_incomplete = false;
+	buf_desc.frame_incomplete = false;
 
 }
 
 void Display::endFrameBuffering() {
 
-	this->buf_desc->frame_incomplete = true;
+	buf_desc.frame_incomplete = true;
 
 }
 

--- a/src/GigaDisplay.cpp
+++ b/src/GigaDisplay.cpp
@@ -25,12 +25,11 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/display.h>
 
-
 #if __has_include ("lvgl.h")
 #include "lvgl.h"
 #endif
 
-/* Private function prototypes -----------------------------------------------*/
+
 #if __has_include ("lvgl.h")
 #if __MBED__
 #include "mbed.h"
@@ -50,6 +49,7 @@ static rtos::Thread lvgl_inc_thd;
 void lvgl_displayFlushing(lv_disp_drv_t * disp, const lv_area_t * area, lv_color_t * color_p);
 #endif
 #endif
+
 
 #ifdef HAS_ARDUINOGRAPHICS
 Display::Display(int width, int height) : ArduinoGraphics(width, height), gdev(NULL)
@@ -187,7 +187,6 @@ bool Display::begin(DisplayPixelFormat pixformat) {
 
   textFont(Font_5x7);
 #endif //arduinoGraphics
-
 
   #if __has_include("lvgl.h")
   printk("initializing LVGL!!!!\n");
@@ -417,7 +416,7 @@ void lvgl_displayFlushing(lv_display_t * disp, const lv_area_t * area, unsigned 
     uint32_t offsetPos  = (area_in_use->x1 + (lcd_x_size * area_in_use->y1)) * sizeof(uint16_t);
     //dsi_lcdDrawImage((void *) px_map, (void *)(dsi_getActiveFrameBuffer() + offsetPos), w, h, DMA2D_INPUT_RGB565);
     //--- cant do this memcpy(px_map, buffer + offsetPos, w * h);
-    Display::write8(0, 0, buffer);
+    //Display::write8(0, 0, buffer);
 #endif
     lv_display_flush_ready(disp);         /* Indicate you are ready with the flushing*/
 }
@@ -431,12 +430,13 @@ void lvgl_displayFlushing(lv_disp_drv_t * disp, const lv_area_t * area, lv_color
     dsi_lcdDrawImage((void *) color_p, (void *)(dsi_getActiveFrameBuffer() + offsetPos), width, height, DMA2D_INPUT_RGB565);
 #else
     //--- cant do this memcpy(px_map, buffer + offsetPos, w * h);
-    Display::write8(0, 0, buffer);
+    //Display::write8(0, 0, buffer);
 
 #endif
     lv_disp_flush_ready(disp);         /* Indicate you are ready with the flushing*/
 }
 #endif
-#endif
+#endif //end lvgl
+
 
 #endif //__ZEPHYR__

--- a/src/GigaDisplay.cpp
+++ b/src/GigaDisplay.cpp
@@ -190,7 +190,7 @@ bool Display::begin(DisplayPixelFormat pixformat) {
 
   #if __has_include("lvgl.h")
   printk("initializing LVGL!!!!\n");
-    /* Initiliaze LVGL library */
+    /* Initialize LVGL library */
     lv_init();
 
 

--- a/src/GigaDisplay.cpp
+++ b/src/GigaDisplay.cpp
@@ -26,6 +26,31 @@
 #include <zephyr/drivers/display.h>
 
 
+#if __has_include ("lvgl.h")
+#include "lvgl.h"
+#endif
+
+/* Private function prototypes -----------------------------------------------*/
+#if __has_include ("lvgl.h")
+#if defined(__MBED__)
+#include "mbed.h"
+#endif
+#if (LVGL_VERSION_MAJOR == 9)
+void lvgl_displayFlushing(lv_display_t * display, const lv_area_t * area, unsigned char * px_map);
+#if defined(__MBED__)
+static void inc_thd() {
+    while (1) {
+      lv_tick_inc(16);
+      delay(16);
+    }
+}
+static rtos::Thread lvgl_inc_thd;
+#endif
+#else
+void lvgl_displayFlushing(lv_disp_drv_t * disp, const lv_area_t * area, lv_color_t * color_p);
+#endif
+
+
 #ifdef HAS_ARDUINOGRAPHICS
 Display::Display(int width, int height) : ArduinoGraphics(width, height), gdev(NULL)
 #else
@@ -128,7 +153,9 @@ bool Display::begin(DisplayPixelFormat pixformat) {
   _width = capabilities.x_resolution;
 #endif
   
-#ifdef HAS_ARDUINOGRAPHICS  
+#if defined( HAS_ARDUINOGRAPHICS) || __has_include ("lvgl.h") 
+  printk("setting up buffer....\n");
+  setBlanking(false);
 #ifdef CONFIG_SHARED_MULTI_HEAP
   void* ptrFB = getFrameBuffer();
   if (ptrFB == nullptr){
@@ -142,6 +169,8 @@ bool Display::begin(DisplayPixelFormat pixformat) {
   SDRAM.begin();
   buffer = (uint16_t*)SDRAM.malloc(this->width() * this-> height() * sizeof(uint16_t));
 #endif    
+  setBlanking(true);
+
   sizeof_framebuffer = width() * height() * sizeof(uint16_t);
   setFrameDesc(width(), height(), width(), sizeof_framebuffer);
   Serial.print("Buffer: 0x"); Serial.println((uint32_t)buffer, HEX);
@@ -149,13 +178,75 @@ bool Display::begin(DisplayPixelFormat pixformat) {
   // turn on the display backlight
   pinMode(74, OUTPUT);
   digitalWrite(74, HIGH);
-    
+#endif
+
+#ifdef HAS_ARDUINOGRAPHICS
   if (!ArduinoGraphics::begin()) {
     return 1; /* Unknown err */
   }
 
   textFont(Font_5x7);
 #endif //arduinoGraphics
+
+
+  #if __has_include("lvgl.h")
+  printk("initializing LVGL!!!!\n");
+    /* Initiliaze LVGL library */
+    lv_init();
+
+
+  #if (LVGL_VERSION_MAJOR == 9)
+    /* Create a draw buffer */
+    static lv_color_t * buf1 = (lv_color_t*)malloc((width() * height() / 10)); /* Declare a buffer for 1/10 screen size */
+    if (buf1 == NULL) {
+      return 2; /* Insuff memory err */
+    }
+
+    lv_display_t *display;
+    if(_rotated) {
+      display = lv_display_create(height(), width());
+      lv_display_set_rotation(display, LV_DISPLAY_ROTATION_270);
+      //display->sw_rotate = 1;
+    } else {
+      display = lv_display_create(width(), height());
+    }
+    lv_display_set_buffers(display, buf1, NULL, width() * height() / 10, LV_DISPLAY_RENDER_MODE_PARTIAL);  /*Initialize the display buffer.*/
+    lv_display_set_flush_cb(display, lvgl_displayFlushing);
+
+    lvgl_inc_thd.start(inc_thd);
+    
+    printk("LVGL Initialized\n");
+
+  #else //LVGL_VERSION_MAJOR
+
+      /* Create a draw buffer */
+    static lv_disp_draw_buf_t draw_buf;
+    static lv_color_t * buf1;
+    buf1 = (lv_color_t*)malloc((width() * height() / 10) * sizeof(lv_color_t)); /* Declare a buffer for 1/10 screen size */
+    if (buf1 == NULL) {
+      return 2; /* Insuff memory err */
+    }
+    lv_disp_draw_buf_init(&draw_buf, buf1, NULL, width() * height() / 10);      /* Initialize the display buffer. */
+
+    /* Initialize display features for LVGL library */
+    static lv_disp_drv_t disp_drv;              /* Descriptor of a display driver */
+    lv_disp_drv_init(&disp_drv);                /* Basic initialization */
+    disp_drv.flush_cb = lvgl_displayFlushing;   /* Set your driver function */
+    disp_drv.draw_buf = &draw_buf;              /* Assign the buffer to the display */
+    if(_rotated) {
+      disp_drv.hor_res = height();        /* Set the horizontal resolution of the display */
+      disp_drv.ver_res = width();         /* Set the vertical resolution of the display */
+      disp_drv.rotated  = LV_DISP_ROT_270;
+    } else {
+      disp_drv.hor_res = width();         /* Set the horizontal resolution of the display */
+      disp_drv.ver_res = height();        /* Set the vertical resolution of the display */
+      disp_drv.rotated  = LV_DISP_ROT_NONE;
+    }
+    disp_drv.sw_rotate = 1;
+    lv_disp_drv_register(&disp_drv);        /* Finally register the driver */
+  #endif
+  #endif
+
 
   return true;
 }
@@ -283,5 +374,67 @@ void Display::lcdClear(uint16_t Color) {
 
 }
 #endif  //HAS_ARDUINOGRAPHICS
+
+#if __has_include("lvgl.h")
+#if (LVGL_VERSION_MAJOR == 9)
+static uint8_t* rotated_buf = nullptr;
+void lvgl_displayFlushing(lv_display_t * disp, const lv_area_t * area, unsigned char * px_map) {
+    uint32_t w     = lv_area_get_width(area);
+    uint32_t h     = lv_area_get_height(area);
+    lv_area_t* area_in_use = (lv_area_t *)area;
+
+    // TODO: find a smart way to tackle sw rotation
+    lv_display_rotation_t rotation = lv_display_get_rotation(disp);
+    lv_area_t rotated_area;
+    if (rotation != LV_DISPLAY_ROTATION_0) {
+        rotated_buf = (uint8_t*)realloc(rotated_buf, w * h * 4);
+        lv_color_format_t cf = lv_display_get_color_format(disp);
+        #if (LVGL_VERSION_MINOR < 2) 
+        rotation = LV_DISPLAY_ROTATION_90; // bugfix: force 90 degree rotation for lvgl 9.1 end earlier
+        #endif
+        lv_draw_sw_rotate(px_map, rotated_buf,
+                          w, h, lv_draw_buf_width_to_stride(w, cf),
+                          lv_draw_buf_width_to_stride(h, cf),
+                          rotation, cf);
+
+        rotated_area.x1 = lv_display_get_vertical_resolution(disp) - area->y2 - 1;
+        rotated_area.y1 = area->x1;
+        //rotated_area.y2 = dsi_getDisplayYSize() - area->x1 - 1;
+        rotated_area.x2 = rotated_area.x1 + h - 1;
+        rotated_area.y2 = rotated_area.y1 + w + 1;
+
+        area_in_use = &rotated_area;
+        px_map = rotated_buf;
+        auto temp = w;
+        w = h;
+        h = temp;
+    }
+
+#if defined(__MBED__)
+    uint32_t offsetPos  = (area_in_use->x1 + (dsi_getDisplayXSize() * area_in_use->y1)) * sizeof(uint16_t);
+    dsi_lcdDrawImage((void *) px_map, (void *)(dsi_getActiveFrameBuffer() + offsetPos), w, h, DMA2D_INPUT_RGB565);
+#else
+    uint32_t offsetPos  = (area_in_use->x1 + (getDisplayXSize() * area_in_use->y1)) * sizeof(uint16_t);
+    //dsi_lcdDrawImage((void *) px_map, (void *)(dsi_getActiveFrameBuffer() + offsetPos), w, h, DMA2D_INPUT_RGB565);
+    memcpy(px_map, buffer + offest, w * h);
+    write8(0, 0, buffer);
+#endif
+    lv_display_flush_ready(disp);         /* Indicate you are ready with the flushing*/
+}
+#else
+void lvgl_displayFlushing(lv_disp_drv_t * disp, const lv_area_t * area, lv_color_t * color_p) {
+    uint32_t width      = lv_area_get_width(area);
+    uint32_t height     = lv_area_get_height(area);
+    uint32_t offsetPos  = (area->x1 + (dsi_getDisplayXSize() * area->y1)) * sizeof(uint16_t);
+#if defined(__MBED__)
+    dsi_lcdDrawImage((void *) color_p, (void *)(dsi_getActiveFrameBuffer() + offsetPos), width, height, DMA2D_INPUT_RGB565);
+#else
+    memcpy(color_p, buffer + offest, w * h);
+    write8(0, 0, buffer);
+#endif
+    lv_disp_flush_ready(disp);         /* Indicate you are ready with the flushing*/
+}
+#endif
+#endif
 
 #endif //__ZEPHYR__

--- a/src/GigaDisplay.h
+++ b/src/GigaDisplay.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2025 Arduino SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#ifndef __GIGA_DISPLAY_H__
+#define __GIGA_DISPLAY_H__
+
+#ifdef __ZEPHYR__
+
+#include "Arduino.h"
+/** 
+ * @enum DisplayPixelFormat
+ * @brief Display pixel format enumeration.
+ * 
+ * The different formats use different numbers of bits per pixel:
+ * - Grayscale (8-bit)
+ * - RGB565 (16-bit)
+ */
+enum DisplayPixelFormat {
+    DISPLAY_RGB565,    /**< RGB565 format (16-bit). */
+    DISPLAY_RGB888    /**< RGB888 format (16-bit). */
+};
+
+// Color definitions
+
+#define RGB565_BLACK 0x0000       /*   0,   0,   0 */
+#define RGB565_NAVY 0x000F        /*   0,   0, 128 */
+#define RGB565_DARKGREEN 0x03E0   /*   0, 128,   0 */
+#define RGB565_DARKCYAN 0x03EF    /*   0, 128, 128 */
+#define RGB565_MAROON 0x7800      /* 128,   0,   0 */
+#define RGB565_PURPLE 0x780F      /* 128,   0, 128 */
+#define RGB565_OLIVE 0x7BE0       /* 128, 128,   0 */
+#define RGB565_LIGHTGREY 0xC618   /* 192, 192, 192 */
+#define RGB565_DARKGREY 0x7BEF    /* 128, 128, 128 */
+#define RGB565_BLUE 0x001F        /*   0,   0, 255 */
+#define RGB565_GREEN 0x07E0       /*   0, 255,   0 */
+#define RGB565_CYAN 0x07FF        /*   0, 255, 255 */
+#define RGB565_RED 0xF800         /* 255,   0,   0 */
+#define RGB565_MAGENTA 0xF81F     /* 255,   0, 255 */
+#define RGB565_YELLOW 0xFFE0      /* 255, 255,   0 */
+#define RGB565_WHITE 0xFFFF       /* 255, 255, 255 */
+#define RGB565_ORANGE 0xFD20      /* 255, 165,   0 */
+#define RGB565_GREENYELLOW 0xAFE5 /* 173, 255,  47 */
+#define RGB565_PINK 0xF81F
+
+/**
+ * @class Display
+ * @brief The main class for controlling a camera.
+ */
+class Display {
+private:
+    const struct device *gdev;
+    struct display_buffer_descriptor *buf_desc;
+    
+ protected:
+    int16_t _height, _width;
+
+public:
+    /**
+    * @brief Construct a new Camera object.
+    */
+    Display();
+
+    /**
+    * @brief Initialize the display
+    */
+    bool begin(DisplayPixelFormat pixformat = DISPLAY_RGB565, int rotation = 0);
+    
+    /**
+    * @brief a frame.
+    * 
+    * @param fb Reference to a FrameBuffer object to store the frame data.
+    * @param timeout Time in milliseconds to wait for a frame (default: 5000).
+    * @return true if the frame is successfully captured, otherwise false.
+    */
+    //bool grabFrame(FrameBuffer &fb, uint32_t timeout = 5000);
+    
+    
+    /**
+    *
+    *
+    *
+    *
+    */
+    int write8(const uint16_t x,
+        const uint16_t y,
+        const void *buf);
+        
+    void setFrameDesc(uint16_t w, uint16_t h, uint16_t pitch, uint32_t buf_size);
+    void startFrameBuffering();
+    void endFrameBuffering();
+
+    int setBlanking(bool on);
+
+    void* getFrameBuffer();
+
+    int16_t width(void)  { return _width; }
+    int16_t height(void) { return _height; }
+
+   
+};
+
+#endif // __GIGA_DISPLAY_H__
+
+#endif // __ZEPHYR__

--- a/src/GigaDisplay.h
+++ b/src/GigaDisplay.h
@@ -21,6 +21,17 @@
 #ifdef __ZEPHYR__
 
 #include "Arduino.h"
+
+#if __has_include ("HasIncludeArduinoGraphics.h")
+#include "SDRAM.h"
+#include "ArduinoGraphics.h"
+#define HAS_ARDUINOGRAPHICS
+
+static uint32_t lcd_x_size = 480;
+static uint32_t lcd_y_size = 800;
+#endif
+
+
 /** 
  * @enum DisplayPixelFormat
  * @brief Display pixel format enumeration.
@@ -60,24 +71,21 @@ enum DisplayPixelFormat {
  * @class Display
  * @brief The main class for controlling a camera.
  */
-class Display {
-private:
-    const struct device *gdev;
-    struct display_buffer_descriptor *buf_desc;
-    
- protected:
-    int16_t _height, _width;
-
+class Display
+#ifdef HAS_ARDUINOGRAPHICS
+ : public ArduinoGraphics
+#endif
+{
 public:
     /**
     * @brief Construct a new Camera object.
     */
-    Display();
+    Display(int width = 800, int height = 480);
 
     /**
     * @brief Initialize the display
     */
-    bool begin(DisplayPixelFormat pixformat = DISPLAY_RGB565, int rotation = 0);
+    bool begin(DisplayPixelFormat pixformat = DISPLAY_RGB565);
     
     /**
     * @brief a frame.
@@ -110,7 +118,58 @@ public:
     int16_t width(void)  { return _width; }
     int16_t height(void) { return _height; }
 
-   
+
+#ifdef HAS_ARDUINOGRAPHICS
+  /**
+   * @brief Clear the display.
+   */
+  void clear();
+
+  /**
+   * @brief Begin drawing operations on the display.
+   */
+  virtual void beginDraw();
+
+  /**
+   * @brief End drawing operations on the display.
+   */
+  virtual void endDraw();
+
+  /**
+   * @brief Set the color of the pixel at the specified coordinates.
+   * 
+   * @param x The x-coordinate of the pixel.
+   * @param y The y-coordinate of the pixel.
+   * @param r The red component of the color.
+   * @param g The green component of the color.
+   * @param b The blue component of the color.
+   */
+  virtual void set(int x, int y, uint8_t r, uint8_t g, uint8_t b);
+  
+  uint32_t getDisplayXSize(){
+    return lcd_x_size;
+  }
+
+  uint32_t getDisplayYSize(){
+    return lcd_y_size;
+  }
+  
+  void lcdClear(uint16_t Color);
+  
+#endif
+
+  
+private:
+    const struct device *gdev;
+    struct display_buffer_descriptor *buf_desc;
+#ifdef HAS_ARDUINOGRAPHICS
+    uint16_t *buffer = nullptr;
+    uint32_t sizeof_framebuffer;
+#endif
+ protected:
+    int16_t _height, _width;
+    bool    _rotated = false;
+
 };
 
 #endif // __GIGA_DISPLAY_H__

--- a/src/GigaDisplay.h
+++ b/src/GigaDisplay.h
@@ -162,7 +162,7 @@ public:
 private:
     const struct device *gdev;
     struct display_buffer_descriptor *buf_desc;
-#ifdef HAS_ARDUINOGRAPHICS
+#if defined(HAS_ARDUINOGRAPHICS)  || __has_include ("lvgl.h") 
     uint16_t *buffer = nullptr;
     uint32_t sizeof_framebuffer;
 #endif

--- a/src/GigaDisplay.h
+++ b/src/GigaDisplay.h
@@ -26,11 +26,10 @@
 #include "SDRAM.h"
 #include "ArduinoGraphics.h"
 #define HAS_ARDUINOGRAPHICS
+#endif
 
 static uint32_t lcd_x_size = 480;
 static uint32_t lcd_y_size = 800;
-#endif
-
 
 /** 
  * @enum DisplayPixelFormat
@@ -77,46 +76,54 @@ class Display
 #endif
 {
 public:
-    /**
-    * @brief Construct a new Camera object.
-    */
-    Display(int width = 800, int height = 480);
+  /**
+  * @brief Construct a new Camera object.
+  */
+  Display(int width = 800, int height = 480);
 
-    /**
-    * @brief Initialize the display
-    */
-    bool begin(DisplayPixelFormat pixformat = DISPLAY_RGB565);
+  /**
+  * @brief Initialize the display
+  */
+  bool begin(DisplayPixelFormat pixformat = DISPLAY_RGB565);
+  
+  /**
+  * @brief a frame.
+  * 
+  * @param fb Reference to a FrameBuffer object to store the frame data.
+  * @param timeout Time in milliseconds to wait for a frame (default: 5000).
+  * @return true if the frame is successfully captured, otherwise false.
+  */
+  //bool grabFrame(FrameBuffer &fb, uint32_t timeout = 5000);
+  
+  
+  /**
+  *
+  *
+  *
+  *
+  */
+  int write8(const uint16_t x,
+      const uint16_t y,
+      const void *buf);
+      
+  void setFrameDesc(uint16_t w, uint16_t h, uint16_t pitch, uint32_t buf_size);
+  void startFrameBuffering();
+  void endFrameBuffering();
+
+  int setBlanking(bool on);
+
+  void* getFrameBuffer();
+
+  int16_t width(void)  { return _width; }
+  int16_t height(void) { return _height; }
     
-    /**
-    * @brief a frame.
-    * 
-    * @param fb Reference to a FrameBuffer object to store the frame data.
-    * @param timeout Time in milliseconds to wait for a frame (default: 5000).
-    * @return true if the frame is successfully captured, otherwise false.
-    */
-    //bool grabFrame(FrameBuffer &fb, uint32_t timeout = 5000);
-    
-    
-    /**
-    *
-    *
-    *
-    *
-    */
-    int write8(const uint16_t x,
-        const uint16_t y,
-        const void *buf);
-        
-    void setFrameDesc(uint16_t w, uint16_t h, uint16_t pitch, uint32_t buf_size);
-    void startFrameBuffering();
-    void endFrameBuffering();
+  uint32_t getDisplayXSize(){
+    return lcd_x_size;
+  }
 
-    int setBlanking(bool on);
-
-    void* getFrameBuffer();
-
-    int16_t width(void)  { return _width; }
-    int16_t height(void) { return _height; }
+  uint32_t getDisplayYSize(){
+    return lcd_y_size;
+  }
 
 
 #ifdef HAS_ARDUINOGRAPHICS
@@ -146,14 +153,6 @@ public:
    */
   virtual void set(int x, int y, uint8_t r, uint8_t g, uint8_t b);
   
-  uint32_t getDisplayXSize(){
-    return lcd_x_size;
-  }
-
-  uint32_t getDisplayYSize(){
-    return lcd_y_size;
-  }
-  
   void lcdClear(uint16_t Color);
   
 #endif
@@ -162,16 +161,13 @@ public:
 private:
     const struct device *gdev;
     struct display_buffer_descriptor *buf_desc;
-#if defined(HAS_ARDUINOGRAPHICS)  || __has_include ("lvgl.h") 
     uint16_t *buffer = nullptr;
     uint32_t sizeof_framebuffer;
-#endif
  protected:
     int16_t _height, _width;
     bool    _rotated = false;
 
 };
 
-#endif // __GIGA_DISPLAY_H__
-
 #endif // __ZEPHYR__
+#endif // __GIGA_DISPLAY_H__

--- a/src/GigaDisplay.h
+++ b/src/GigaDisplay.h
@@ -161,8 +161,10 @@ public:
 private:
     const struct device *gdev;
     struct display_buffer_descriptor *buf_desc;
+#if defined( HAS_ARDUINOGRAPHICS) || __has_include ("lvgl.h")
     uint16_t *buffer = nullptr;
     uint32_t sizeof_framebuffer;
+#endif
  protected:
     int16_t _height, _width;
     bool    _rotated = false;

--- a/src/GigaDisplay.h
+++ b/src/GigaDisplay.h
@@ -21,6 +21,9 @@
 #ifdef __ZEPHYR__
 
 #include "Arduino.h"
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/display.h>
 
 #if __has_include ("HasIncludeArduinoGraphics.h")
 #include "SDRAM.h"
@@ -160,7 +163,7 @@ public:
   
 private:
     const struct device *gdev;
-    struct display_buffer_descriptor *buf_desc;
+    struct display_buffer_descriptor buf_desc;
 #if defined( HAS_ARDUINOGRAPHICS) || __has_include ("lvgl.h")
     uint16_t *buffer = nullptr;
     uint32_t sizeof_framebuffer;

--- a/src/GigaDisplayRGB.h
+++ b/src/GigaDisplayRGB.h
@@ -13,6 +13,7 @@ class GigaDisplayRGB {
         void writeByte(uint8_t,uint8_t);
 };
 
+#ifdef __MBED__
 #include "mbed.h"
 using namespace std::chrono_literals;
 using namespace std::chrono;
@@ -48,6 +49,7 @@ class GigaDisplayBacklight {
         mbed::Ticker* ticker;
         mbed::DigitalOut* pin;
         int intensity;
+#endif
 };
 
 #endif

--- a/src/GigaDisplayRGB.h
+++ b/src/GigaDisplayRGB.h
@@ -49,7 +49,6 @@ class GigaDisplayBacklight {
         mbed::Ticker* ticker;
         mbed::DigitalOut* pin;
         int intensity;
-#endif
 };
-
+#endif  //MBED
 #endif

--- a/src/GigaDisplayRGB.h
+++ b/src/GigaDisplayRGB.h
@@ -47,7 +47,7 @@ class GigaDisplayBacklight {
         }
     private:
         mbed::Ticker* ticker;
-        mbed::DigitalOut* pin
+        mbed::DigitalOut* pin;
         int intensity;
 };
 #endif  //MBED

--- a/src/GigaDisplayRGB.h
+++ b/src/GigaDisplayRGB.h
@@ -47,8 +47,9 @@ class GigaDisplayBacklight {
         }
     private:
         mbed::Ticker* ticker;
-        mbed::DigitalOut* pin;
+        mbed::DigitalOut* pin
         int intensity;
 };
 #endif  //MBED
+
 #endif

--- a/src/lv_conf.h
+++ b/src/lv_conf.h
@@ -1,0 +1,6 @@
+//#if (LVGL_VERSION_MAJOR == 9)
+#if __has_include("draw/sw/blend/neon/lv_blend_neon.h")
+#include "lv_conf_9.h"
+#else
+#include "lv_conf_8.h"
+#endif

--- a/src/lv_conf_8.h
+++ b/src/lv_conf_8.h
@@ -1,0 +1,762 @@
+/**
+ * @file lv_conf.h
+ * Configuration file for v8.3.5
+ */
+
+/*
+ * Copy this file as `lv_conf.h`
+ * 1. simply next to the `lvgl` folder
+ * 2. or any other places and
+ *    - define `LV_CONF_INCLUDE_SIMPLE`
+ *    - add the path as include path
+ */
+
+/* clang-format off */
+#if 1 /*Set it to "1" to enable content*/
+
+#ifndef LV_CONF_H
+#define LV_CONF_H
+
+#include <stdint.h>
+
+/*====================
+   COLOR SETTINGS
+ *====================*/
+
+/*Color depth: 1 (1 byte per pixel), 8 (RGB332), 16 (RGB565), 32 (ARGB8888)*/
+#define LV_COLOR_DEPTH 16
+
+/*Swap the 2 bytes of RGB565 color. Useful if the display has an 8-bit interface (e.g. SPI)*/
+#define LV_COLOR_16_SWAP 0
+
+/*Enable features to draw on transparent background.
+ *It's required if opa, and transform_* style properties are used.
+ *Can be also used if the UI is above another layer, e.g. an OSD menu or video player.*/
+#define LV_COLOR_SCREEN_TRANSP 0
+
+/* Adjust color mix functions rounding. GPUs might calculate color mix (blending) differently.
+ * 0: round down, 64: round up from x.75, 128: round up from half, 192: round up from x.25, 254: round up */
+#define LV_COLOR_MIX_ROUND_OFS 0
+
+/*Images pixels with this color will not be drawn if they are chroma keyed)*/
+#define LV_COLOR_CHROMA_KEY lv_color_hex(0x00ff00)         /*pure green*/
+
+/*=========================
+   MEMORY SETTINGS
+ *=========================*/
+
+/*1: use custom malloc/free, 0: use the built-in `lv_mem_alloc()` and `lv_mem_free()`*/
+#define LV_MEM_CUSTOM 0
+#if LV_MEM_CUSTOM == 0
+    /*Size of the memory available for `lv_mem_alloc()` in bytes (>= 2kB)*/
+    #define LV_MEM_SIZE (48U * 1024U)          /*[bytes]*/
+
+    /*Set an address for the memory pool instead of allocating it as a normal array. Can be in external SRAM too.*/
+    #define LV_MEM_ADR 0     /*0: unused*/
+    /*Instead of an address give a memory allocator that will be called to get a memory pool for LVGL. E.g. my_malloc*/
+    #if LV_MEM_ADR == 0
+        #undef LV_MEM_POOL_INCLUDE
+        #undef LV_MEM_POOL_ALLOC
+    #endif
+
+#else       /*LV_MEM_CUSTOM*/
+    #define LV_MEM_CUSTOM_INCLUDE <stdlib.h>   /*Header for the dynamic memory function*/
+    #define LV_MEM_CUSTOM_ALLOC   malloc
+    #define LV_MEM_CUSTOM_FREE    free
+    #define LV_MEM_CUSTOM_REALLOC realloc
+#endif     /*LV_MEM_CUSTOM*/
+
+/*Number of the intermediate memory buffer used during rendering and other internal processing mechanisms.
+ *You will see an error log message if there wasn't enough buffers. */
+#define LV_MEM_BUF_MAX_NUM 16
+
+/*Use the standard `memcpy` and `memset` instead of LVGL's own functions. (Might or might not be faster).*/
+#define LV_MEMCPY_MEMSET_STD 0
+
+/*====================
+   HAL SETTINGS
+ *====================*/
+
+/*Default display refresh period. LVG will redraw changed areas with this period time*/
+#define LV_DISP_DEF_REFR_PERIOD 30      /*[ms]*/
+
+/*Input device read period in milliseconds*/
+#define LV_INDEV_DEF_READ_PERIOD 30     /*[ms]*/
+
+/*Use a custom tick source that tells the elapsed time in milliseconds.
+ *It removes the need to manually update the tick with `lv_tick_inc()`)*/
+#define LV_TICK_CUSTOM 1
+#if LV_TICK_CUSTOM
+    #define LV_TICK_CUSTOM_INCLUDE "Arduino.h"         /*Header for the system time function*/
+    #define LV_TICK_CUSTOM_SYS_TIME_EXPR (millis())    /*Expression evaluating to current system time in ms*/
+    /*If using lvgl as ESP32 component*/
+    // #define LV_TICK_CUSTOM_INCLUDE "esp_timer.h"
+    // #define LV_TICK_CUSTOM_SYS_TIME_EXPR ((esp_timer_get_time() / 1000LL))
+#endif   /*LV_TICK_CUSTOM*/
+
+/*Default Dot Per Inch. Used to initialize default sizes such as widgets sized, style paddings.
+ *(Not so important, you can adjust it to modify default sizes and spaces)*/
+#define LV_DPI_DEF 130     /*[px/inch]*/
+
+/*=======================
+ * FEATURE CONFIGURATION
+ *=======================*/
+
+/*-------------
+ * Drawing
+ *-----------*/
+
+/*Enable complex draw engine.
+ *Required to draw shadow, gradient, rounded corners, circles, arc, skew lines, image transformations or any masks*/
+#define LV_DRAW_COMPLEX 1
+#if LV_DRAW_COMPLEX != 0
+
+    /*Allow buffering some shadow calculation.
+    *LV_SHADOW_CACHE_SIZE is the max. shadow size to buffer, where shadow size is `shadow_width + radius`
+    *Caching has LV_SHADOW_CACHE_SIZE^2 RAM cost*/
+    #define LV_SHADOW_CACHE_SIZE 0
+
+    /* Set number of maximally cached circle data.
+    * The circumference of 1/4 circle are saved for anti-aliasing
+    * radius * 4 bytes are used per circle (the most often used radiuses are saved)
+    * 0: to disable caching */
+    #define LV_CIRCLE_CACHE_SIZE 4
+#endif /*LV_DRAW_COMPLEX*/
+
+/**
+ * "Simple layers" are used when a widget has `style_opa < 255` to buffer the widget into a layer
+ * and blend it as an image with the given opacity.
+ * Note that `bg_opa`, `text_opa` etc don't require buffering into layer)
+ * The widget can be buffered in smaller chunks to avoid using large buffers.
+ *
+ * - LV_LAYER_SIMPLE_BUF_SIZE: [bytes] the optimal target buffer size. LVGL will try to allocate it
+ * - LV_LAYER_SIMPLE_FALLBACK_BUF_SIZE: [bytes]  used if `LV_LAYER_SIMPLE_BUF_SIZE` couldn't be allocated.
+ *
+ * Both buffer sizes are in bytes.
+ * "Transformed layers" (where transform_angle/zoom properties are used) use larger buffers
+ * and can't be drawn in chunks. So these settings affects only widgets with opacity.
+ */
+#define LV_LAYER_SIMPLE_BUF_SIZE          (24 * 1024)
+#define LV_LAYER_SIMPLE_FALLBACK_BUF_SIZE (3 * 1024)
+
+/*Default image cache size. Image caching keeps the images opened.
+ *If only the built-in image formats are used there is no real advantage of caching. (I.e. if no new image decoder is added)
+ *With complex image decoders (e.g. PNG or JPG) caching can save the continuous open/decode of images.
+ *However the opened images might consume additional RAM.
+ *0: to disable caching*/
+#define LV_IMG_CACHE_DEF_SIZE 0
+
+/*Number of stops allowed per gradient. Increase this to allow more stops.
+ *This adds (sizeof(lv_color_t) + 1) bytes per additional stop*/
+#define LV_GRADIENT_MAX_STOPS 2
+
+/*Default gradient buffer size.
+ *When LVGL calculates the gradient "maps" it can save them into a cache to avoid calculating them again.
+ *LV_GRAD_CACHE_DEF_SIZE sets the size of this cache in bytes.
+ *If the cache is too small the map will be allocated only while it's required for the drawing.
+ *0 mean no caching.*/
+#define LV_GRAD_CACHE_DEF_SIZE 0
+
+/*Allow dithering the gradients (to achieve visual smooth color gradients on limited color depth display)
+ *LV_DITHER_GRADIENT implies allocating one or two more lines of the object's rendering surface
+ *The increase in memory consumption is (32 bits * object width) plus 24 bits * object width if using error diffusion */
+#define LV_DITHER_GRADIENT 0
+#if LV_DITHER_GRADIENT
+    /*Add support for error diffusion dithering.
+     *Error diffusion dithering gets a much better visual result, but implies more CPU consumption and memory when drawing.
+     *The increase in memory consumption is (24 bits * object's width)*/
+    #define LV_DITHER_ERROR_DIFFUSION 0
+#endif
+
+/*Maximum buffer size to allocate for rotation.
+ *Only used if software rotation is enabled in the display driver.*/
+#define LV_DISP_ROT_MAX_BUF (10*1024)
+
+/*-------------
+ * GPU
+ *-----------*/
+
+/*Use Arm's 2D acceleration library Arm-2D */
+#define LV_USE_GPU_ARM2D 0
+
+/*Use STM32's DMA2D (aka Chrom Art) GPU*/
+#define LV_USE_GPU_STM32_DMA2D 0
+#if LV_USE_GPU_STM32_DMA2D
+    /*Must be defined to include path of CMSIS header of target processor
+    e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
+    #define LV_GPU_DMA2D_CMSIS_INCLUDE
+#endif
+
+/*Use SWM341's DMA2D GPU*/
+#define LV_USE_GPU_SWM341_DMA2D 0
+#if LV_USE_GPU_SWM341_DMA2D
+    #define LV_GPU_SWM341_DMA2D_INCLUDE "SWM341.h"
+#endif
+
+/*Use NXP's PXP GPU iMX RTxxx platforms*/
+#define LV_USE_GPU_NXP_PXP 0
+#if LV_USE_GPU_NXP_PXP
+    /*1: Add default bare metal and FreeRTOS interrupt handling routines for PXP (lv_gpu_nxp_pxp_osa.c)
+    *   and call lv_gpu_nxp_pxp_init() automatically during lv_init(). Note that symbol SDK_OS_FREE_RTOS
+    *   has to be defined in order to use FreeRTOS OSA, otherwise bare-metal implementation is selected.
+    *0: lv_gpu_nxp_pxp_init() has to be called manually before lv_init()
+    */
+    #define LV_USE_GPU_NXP_PXP_AUTO_INIT 0
+#endif
+
+/*Use NXP's VG-Lite GPU iMX RTxxx platforms*/
+#define LV_USE_GPU_NXP_VG_LITE 0
+
+/*Use SDL renderer API*/
+#define LV_USE_GPU_SDL 0
+#if LV_USE_GPU_SDL
+    #define LV_GPU_SDL_INCLUDE_PATH <SDL2/SDL.h>
+    /*Texture cache size, 8MB by default*/
+    #define LV_GPU_SDL_LRU_SIZE (1024 * 1024 * 8)
+    /*Custom blend mode for mask drawing, disable if you need to link with older SDL2 lib*/
+    #define LV_GPU_SDL_CUSTOM_BLEND_MODE (SDL_VERSION_ATLEAST(2, 0, 6))
+#endif
+
+/*-------------
+ * Logging
+ *-----------*/
+
+/*Enable the log module*/
+#define LV_USE_LOG 0
+#if LV_USE_LOG
+
+    /*How important log should be added:
+    *LV_LOG_LEVEL_TRACE       A lot of logs to give detailed information
+    *LV_LOG_LEVEL_INFO        Log important events
+    *LV_LOG_LEVEL_WARN        Log if something unwanted happened but didn't cause a problem
+    *LV_LOG_LEVEL_ERROR       Only critical issue, when the system may fail
+    *LV_LOG_LEVEL_USER        Only logs added by the user
+    *LV_LOG_LEVEL_NONE        Do not log anything*/
+    #define LV_LOG_LEVEL LV_LOG_LEVEL_WARN
+
+    /*1: Print the log with 'printf';
+    *0: User need to register a callback with `lv_log_register_print_cb()`*/
+    #define LV_LOG_PRINTF 0
+
+    /*Enable/disable LV_LOG_TRACE in modules that produces a huge number of logs*/
+    #define LV_LOG_TRACE_MEM        1
+    #define LV_LOG_TRACE_TIMER      1
+    #define LV_LOG_TRACE_INDEV      1
+    #define LV_LOG_TRACE_DISP_REFR  1
+    #define LV_LOG_TRACE_EVENT      1
+    #define LV_LOG_TRACE_OBJ_CREATE 1
+    #define LV_LOG_TRACE_LAYOUT     1
+    #define LV_LOG_TRACE_ANIM       1
+
+#endif  /*LV_USE_LOG*/
+
+/*-------------
+ * Asserts
+ *-----------*/
+
+/*Enable asserts if an operation is failed or an invalid data is found.
+ *If LV_USE_LOG is enabled an error message will be printed on failure*/
+#define LV_USE_ASSERT_NULL          1   /*Check if the parameter is NULL. (Very fast, recommended)*/
+#define LV_USE_ASSERT_MALLOC        1   /*Checks is the memory is successfully allocated or no. (Very fast, recommended)*/
+#define LV_USE_ASSERT_STYLE         0   /*Check if the styles are properly initialized. (Very fast, recommended)*/
+#define LV_USE_ASSERT_MEM_INTEGRITY 0   /*Check the integrity of `lv_mem` after critical operations. (Slow)*/
+#define LV_USE_ASSERT_OBJ           0   /*Check the object's type and existence (e.g. not deleted). (Slow)*/
+
+/*Add a custom handler when assert happens e.g. to restart the MCU*/
+#define LV_ASSERT_HANDLER_INCLUDE <stdint.h>
+#define LV_ASSERT_HANDLER while(1);   /*Halt by default*/
+
+/*-------------
+ * Others
+ *-----------*/
+
+/*1: Show CPU usage and FPS count*/
+#define LV_USE_PERF_MONITOR 0
+#if LV_USE_PERF_MONITOR
+    #define LV_USE_PERF_MONITOR_POS LV_ALIGN_BOTTOM_RIGHT
+#endif
+
+/*1: Show the used memory and the memory fragmentation
+ * Requires LV_MEM_CUSTOM = 0*/
+#define LV_USE_MEM_MONITOR 0
+#if LV_USE_MEM_MONITOR
+    #define LV_USE_MEM_MONITOR_POS LV_ALIGN_BOTTOM_LEFT
+#endif
+
+/*1: Draw random colored rectangles over the redrawn areas*/
+#define LV_USE_REFR_DEBUG 0
+
+/*Change the built in (v)snprintf functions*/
+#define LV_SPRINTF_CUSTOM 0
+#if LV_SPRINTF_CUSTOM
+    #define LV_SPRINTF_INCLUDE <stdio.h>
+    #define lv_snprintf  snprintf
+    #define lv_vsnprintf vsnprintf
+#else   /*LV_SPRINTF_CUSTOM*/
+    #define LV_SPRINTF_USE_FLOAT 0
+#endif  /*LV_SPRINTF_CUSTOM*/
+
+#define LV_USE_USER_DATA 1
+
+/*Garbage Collector settings
+ *Used if lvgl is bound to higher level language and the memory is managed by that language*/
+#define LV_ENABLE_GC 0
+#if LV_ENABLE_GC != 0
+    #define LV_GC_INCLUDE "gc.h"                           /*Include Garbage Collector related things*/
+#endif /*LV_ENABLE_GC*/
+
+/*=====================
+ *  COMPILER SETTINGS
+ *====================*/
+
+/*For big endian systems set to 1*/
+#define LV_BIG_ENDIAN_SYSTEM 0
+
+/*Define a custom attribute to `lv_tick_inc` function*/
+#define LV_ATTRIBUTE_TICK_INC
+
+/*Define a custom attribute to `lv_timer_handler` function*/
+#define LV_ATTRIBUTE_TIMER_HANDLER
+
+/*Define a custom attribute to `lv_disp_flush_ready` function*/
+#define LV_ATTRIBUTE_FLUSH_READY
+
+/*Required alignment size for buffers*/
+#define LV_ATTRIBUTE_MEM_ALIGN_SIZE 1
+
+/*Will be added where memories needs to be aligned (with -Os data might not be aligned to boundary by default).
+ * E.g. __attribute__((aligned(4)))*/
+#define LV_ATTRIBUTE_MEM_ALIGN
+
+/*Attribute to mark large constant arrays for example font's bitmaps*/
+#define LV_ATTRIBUTE_LARGE_CONST
+
+/*Compiler prefix for a big array declaration in RAM*/
+#define LV_ATTRIBUTE_LARGE_RAM_ARRAY
+
+/*Place performance critical functions into a faster memory (e.g RAM)*/
+#define LV_ATTRIBUTE_FAST_MEM
+
+/*Prefix variables that are used in GPU accelerated operations, often these need to be placed in RAM sections that are DMA accessible*/
+#define LV_ATTRIBUTE_DMA
+
+/*Export integer constant to binding. This macro is used with constants in the form of LV_<CONST> that
+ *should also appear on LVGL binding API such as Micropython.*/
+#define LV_EXPORT_CONST_INT(int_value) struct _silence_gcc_warning /*The default value just prevents GCC warning*/
+
+/*Extend the default -32k..32k coordinate range to -4M..4M by using int32_t for coordinates instead of int16_t*/
+#define LV_USE_LARGE_COORD 0
+
+/*==================
+ *   FONT USAGE
+ *===================*/
+
+/*Montserrat fonts with ASCII range and some symbols using bpp = 4
+ *https://fonts.google.com/specimen/Montserrat*/
+#define LV_FONT_MONTSERRAT_8  0
+#define LV_FONT_MONTSERRAT_10 0
+#define LV_FONT_MONTSERRAT_12 0
+#define LV_FONT_MONTSERRAT_14 1
+#define LV_FONT_MONTSERRAT_16 0
+#define LV_FONT_MONTSERRAT_18 0
+#define LV_FONT_MONTSERRAT_20 0
+#define LV_FONT_MONTSERRAT_22 0
+#define LV_FONT_MONTSERRAT_24 0
+#define LV_FONT_MONTSERRAT_26 0
+#define LV_FONT_MONTSERRAT_28 0
+#define LV_FONT_MONTSERRAT_30 0
+#define LV_FONT_MONTSERRAT_32 0
+#define LV_FONT_MONTSERRAT_34 0
+#define LV_FONT_MONTSERRAT_36 0
+#define LV_FONT_MONTSERRAT_38 0
+#define LV_FONT_MONTSERRAT_40 0
+#define LV_FONT_MONTSERRAT_42 0
+#define LV_FONT_MONTSERRAT_44 0
+#define LV_FONT_MONTSERRAT_46 0
+#define LV_FONT_MONTSERRAT_48 0
+
+/*Demonstrate special features*/
+#define LV_FONT_MONTSERRAT_12_SUBPX      0
+#define LV_FONT_MONTSERRAT_28_COMPRESSED 0  /*bpp = 3*/
+#define LV_FONT_DEJAVU_16_PERSIAN_HEBREW 0  /*Hebrew, Arabic, Persian letters and all their forms*/
+#define LV_FONT_SIMSUN_16_CJK            0  /*1000 most common CJK radicals*/
+
+/*Pixel perfect monospace fonts*/
+#define LV_FONT_UNSCII_8  0
+#define LV_FONT_UNSCII_16 0
+
+/*Optionally declare custom fonts here.
+ *You can use these fonts as default font too and they will be available globally.
+ *E.g. #define LV_FONT_CUSTOM_DECLARE   LV_FONT_DECLARE(my_font_1) LV_FONT_DECLARE(my_font_2)*/
+#define LV_FONT_CUSTOM_DECLARE
+
+/*Always set a default font*/
+#define LV_FONT_DEFAULT &lv_font_montserrat_14
+
+/*Enable handling large font and/or fonts with a lot of characters.
+ *The limit depends on the font size, font face and bpp.
+ *Compiler error will be triggered if a font needs it.*/
+#define LV_FONT_FMT_TXT_LARGE 0
+
+/*Enables/disables support for compressed fonts.*/
+#define LV_USE_FONT_COMPRESSED 0
+
+/*Enable subpixel rendering*/
+#define LV_USE_FONT_SUBPX 0
+#if LV_USE_FONT_SUBPX
+    /*Set the pixel order of the display. Physical order of RGB channels. Doesn't matter with "normal" fonts.*/
+    #define LV_FONT_SUBPX_BGR 0  /*0: RGB; 1:BGR order*/
+#endif
+
+/*Enable drawing placeholders when glyph dsc is not found*/
+#define LV_USE_FONT_PLACEHOLDER 1
+
+/*=================
+ *  TEXT SETTINGS
+ *=================*/
+
+/**
+ * Select a character encoding for strings.
+ * Your IDE or editor should have the same character encoding
+ * - LV_TXT_ENC_UTF8
+ * - LV_TXT_ENC_ASCII
+ */
+#define LV_TXT_ENC LV_TXT_ENC_UTF8
+
+/*Can break (wrap) texts on these chars*/
+#define LV_TXT_BREAK_CHARS " ,.;:-_"
+
+/*If a word is at least this long, will break wherever "prettiest"
+ *To disable, set to a value <= 0*/
+#define LV_TXT_LINE_BREAK_LONG_LEN 0
+
+/*Minimum number of characters in a long word to put on a line before a break.
+ *Depends on LV_TXT_LINE_BREAK_LONG_LEN.*/
+#define LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN 3
+
+/*Minimum number of characters in a long word to put on a line after a break.
+ *Depends on LV_TXT_LINE_BREAK_LONG_LEN.*/
+#define LV_TXT_LINE_BREAK_LONG_POST_MIN_LEN 3
+
+/*The control character to use for signalling text recoloring.*/
+#define LV_TXT_COLOR_CMD "#"
+
+/*Support bidirectional texts. Allows mixing Left-to-Right and Right-to-Left texts.
+ *The direction will be processed according to the Unicode Bidirectional Algorithm:
+ *https://www.w3.org/International/articles/inline-bidi-markup/uba-basics*/
+#define LV_USE_BIDI 0
+#if LV_USE_BIDI
+    /*Set the default direction. Supported values:
+    *`LV_BASE_DIR_LTR` Left-to-Right
+    *`LV_BASE_DIR_RTL` Right-to-Left
+    *`LV_BASE_DIR_AUTO` detect texts base direction*/
+    #define LV_BIDI_BASE_DIR_DEF LV_BASE_DIR_AUTO
+#endif
+
+/*Enable Arabic/Persian processing
+ *In these languages characters should be replaced with an other form based on their position in the text*/
+#define LV_USE_ARABIC_PERSIAN_CHARS 0
+
+/*==================
+ *  WIDGET USAGE
+ *================*/
+
+/*Documentation of the widgets: https://docs.lvgl.io/latest/en/html/widgets/index.html*/
+
+#define LV_USE_ARC        1
+
+#define LV_USE_BAR        1
+
+#define LV_USE_BTN        1
+
+#define LV_USE_BTNMATRIX  1
+
+#define LV_USE_CANVAS     1
+
+#define LV_USE_CHECKBOX   1
+
+#define LV_USE_DROPDOWN   1   /*Requires: lv_label*/
+
+#define LV_USE_IMG        1   /*Requires: lv_label*/
+
+#define LV_USE_LABEL      1
+#if LV_USE_LABEL
+    #define LV_LABEL_TEXT_SELECTION 1 /*Enable selecting text of the label*/
+    #define LV_LABEL_LONG_TXT_HINT 1  /*Store some extra info in labels to speed up drawing of very long texts*/
+#endif
+
+#define LV_USE_LINE       1
+
+#define LV_USE_ROLLER     1   /*Requires: lv_label*/
+#if LV_USE_ROLLER
+    #define LV_ROLLER_INF_PAGES 7 /*Number of extra "pages" when the roller is infinite*/
+#endif
+
+#define LV_USE_SLIDER     1   /*Requires: lv_bar*/
+
+#define LV_USE_SWITCH     1
+
+#define LV_USE_TEXTAREA   1   /*Requires: lv_label*/
+#if LV_USE_TEXTAREA != 0
+    #define LV_TEXTAREA_DEF_PWD_SHOW_TIME 1500    /*ms*/
+#endif
+
+#define LV_USE_TABLE      1
+
+/*==================
+ * EXTRA COMPONENTS
+ *==================*/
+
+/*-----------
+ * Widgets
+ *----------*/
+#define LV_USE_ANIMIMG    1
+
+#define LV_USE_CALENDAR   1
+#if LV_USE_CALENDAR
+    #define LV_CALENDAR_WEEK_STARTS_MONDAY 0
+    #if LV_CALENDAR_WEEK_STARTS_MONDAY
+        #define LV_CALENDAR_DEFAULT_DAY_NAMES {"Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"}
+    #else
+        #define LV_CALENDAR_DEFAULT_DAY_NAMES {"Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"}
+    #endif
+
+    #define LV_CALENDAR_DEFAULT_MONTH_NAMES {"January", "February", "March",  "April", "May",  "June", "July", "August", "September", "October", "November", "December"}
+    #define LV_USE_CALENDAR_HEADER_ARROW 1
+    #define LV_USE_CALENDAR_HEADER_DROPDOWN 1
+#endif  /*LV_USE_CALENDAR*/
+
+#define LV_USE_CHART      1
+
+#define LV_USE_COLORWHEEL 1
+
+#define LV_USE_IMGBTN     1
+
+#define LV_USE_KEYBOARD   1
+
+#define LV_USE_LED        1
+
+#define LV_USE_LIST       1
+
+#define LV_USE_MENU       1
+
+#define LV_USE_METER      1
+
+#define LV_USE_MSGBOX     1
+
+#define LV_USE_SPAN       1
+#if LV_USE_SPAN
+    /*A line text can contain maximum num of span descriptor */
+    #define LV_SPAN_SNIPPET_STACK_SIZE 64
+#endif
+
+#define LV_USE_SPINBOX    1
+
+#define LV_USE_SPINNER    1
+
+#define LV_USE_TABVIEW    1
+
+#define LV_USE_TILEVIEW   1
+
+#define LV_USE_WIN        1
+
+/*-----------
+ * Themes
+ *----------*/
+
+/*A simple, impressive and very complete theme*/
+#define LV_USE_THEME_DEFAULT 1
+#if LV_USE_THEME_DEFAULT
+
+    /*0: Light mode; 1: Dark mode*/
+    #define LV_THEME_DEFAULT_DARK 0
+
+    /*1: Enable grow on press*/
+    #define LV_THEME_DEFAULT_GROW 1
+
+    /*Default transition time in [ms]*/
+    #define LV_THEME_DEFAULT_TRANSITION_TIME 80
+#endif /*LV_USE_THEME_DEFAULT*/
+
+/*A very simple theme that is a good starting point for a custom theme*/
+#define LV_USE_THEME_BASIC 1
+
+/*A theme designed for monochrome displays*/
+#define LV_USE_THEME_MONO 1
+
+/*-----------
+ * Layouts
+ *----------*/
+
+/*A layout similar to Flexbox in CSS.*/
+#define LV_USE_FLEX 1
+
+/*A layout similar to Grid in CSS.*/
+#define LV_USE_GRID 1
+
+/*---------------------
+ * 3rd party libraries
+ *--------------------*/
+
+/*File system interfaces for common APIs */
+
+/*API for fopen, fread, etc*/
+#define LV_USE_FS_STDIO 0
+#if LV_USE_FS_STDIO
+    #define LV_FS_STDIO_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+    #define LV_FS_STDIO_PATH ""         /*Set the working directory. File/directory paths will be appended to it.*/
+    #define LV_FS_STDIO_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
+#endif
+
+/*API for open, read, etc*/
+#define LV_USE_FS_POSIX 0
+#if LV_USE_FS_POSIX
+    #define LV_FS_POSIX_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+    #define LV_FS_POSIX_PATH ""         /*Set the working directory. File/directory paths will be appended to it.*/
+    #define LV_FS_POSIX_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
+#endif
+
+/*API for CreateFile, ReadFile, etc*/
+#define LV_USE_FS_WIN32 0
+#if LV_USE_FS_WIN32
+    #define LV_FS_WIN32_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+    #define LV_FS_WIN32_PATH ""         /*Set the working directory. File/directory paths will be appended to it.*/
+    #define LV_FS_WIN32_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
+#endif
+
+/*API for FATFS (needs to be added separately). Uses f_open, f_read, etc*/
+#define LV_USE_FS_FATFS 0
+#if LV_USE_FS_FATFS
+    #define LV_FS_FATFS_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+    #define LV_FS_FATFS_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
+#endif
+
+/*PNG decoder library*/
+#define LV_USE_PNG 0
+
+/*BMP decoder library*/
+#define LV_USE_BMP 0
+
+/* JPG + split JPG decoder library.
+ * Split JPG is a custom format optimized for embedded systems. */
+#define LV_USE_SJPG 0
+
+/*GIF decoder library*/
+#define LV_USE_GIF 0
+
+/*QR code library*/
+#define LV_USE_QRCODE 0
+
+/*FreeType library*/
+#define LV_USE_FREETYPE 0
+#if LV_USE_FREETYPE
+    /*Memory used by FreeType to cache characters [bytes] (-1: no caching)*/
+    #define LV_FREETYPE_CACHE_SIZE (16 * 1024)
+    #if LV_FREETYPE_CACHE_SIZE >= 0
+        /* 1: bitmap cache use the sbit cache, 0:bitmap cache use the image cache. */
+        /* sbit cache:it is much more memory efficient for small bitmaps(font size < 256) */
+        /* if font size >= 256, must be configured as image cache */
+        #define LV_FREETYPE_SBIT_CACHE 0
+        /* Maximum number of opened FT_Face/FT_Size objects managed by this cache instance. */
+        /* (0:use system defaults) */
+        #define LV_FREETYPE_CACHE_FT_FACES 0
+        #define LV_FREETYPE_CACHE_FT_SIZES 0
+    #endif
+#endif
+
+/*Rlottie library*/
+#define LV_USE_RLOTTIE 0
+
+/*FFmpeg library for image decoding and playing videos
+ *Supports all major image formats so do not enable other image decoder with it*/
+#define LV_USE_FFMPEG 0
+#if LV_USE_FFMPEG
+    /*Dump input information to stderr*/
+    #define LV_FFMPEG_DUMP_FORMAT 0
+#endif
+
+/*-----------
+ * Others
+ *----------*/
+
+/*1: Enable API to take snapshot for object*/
+#define LV_USE_SNAPSHOT 0
+
+/*1: Enable Monkey test*/
+#define LV_USE_MONKEY 0
+
+/*1: Enable grid navigation*/
+#define LV_USE_GRIDNAV 0
+
+/*1: Enable lv_obj fragment*/
+#define LV_USE_FRAGMENT 0
+
+/*1: Support using images as font in label or span widgets */
+#define LV_USE_IMGFONT 0
+
+/*1: Enable a published subscriber based messaging system */
+#define LV_USE_MSG 0
+
+/*1: Enable Pinyin input method*/
+/*Requires: lv_keyboard*/
+#define LV_USE_IME_PINYIN 0
+#if LV_USE_IME_PINYIN
+    /*1: Use default thesaurus*/
+    /*If you do not use the default thesaurus, be sure to use `lv_ime_pinyin` after setting the thesauruss*/
+    #define LV_IME_PINYIN_USE_DEFAULT_DICT 1
+    /*Set the maximum number of candidate panels that can be displayed*/
+    /*This needs to be adjusted according to the size of the screen*/
+    #define LV_IME_PINYIN_CAND_TEXT_NUM 6
+
+    /*Use 9 key input(k9)*/
+    #define LV_IME_PINYIN_USE_K9_MODE      1
+    #if LV_IME_PINYIN_USE_K9_MODE == 1
+        #define LV_IME_PINYIN_K9_CAND_TEXT_NUM 3
+    #endif // LV_IME_PINYIN_USE_K9_MODE
+#endif
+
+/*==================
+* EXAMPLES
+*==================*/
+
+/*Enable the examples to be built with the library*/
+#define LV_BUILD_EXAMPLES 1
+
+/*===================
+ * DEMO USAGE
+ ====================*/
+
+/*Show some widget. It might be required to increase `LV_MEM_SIZE` */
+#define LV_USE_DEMO_WIDGETS 0
+#if LV_USE_DEMO_WIDGETS
+#define LV_DEMO_WIDGETS_SLIDESHOW 0
+#endif
+
+/*Demonstrate the usage of encoder and keyboard*/
+#define LV_USE_DEMO_KEYPAD_AND_ENCODER 0
+
+/*Benchmark your system*/
+#define LV_USE_DEMO_BENCHMARK 0
+#if LV_USE_DEMO_BENCHMARK
+/*Use RGB565A8 images with 16 bit color depth instead of ARGB8565*/
+#define LV_DEMO_BENCHMARK_RGB565A8 0
+#endif
+
+/*Stress test for LVGL*/
+#define LV_USE_DEMO_STRESS 0
+
+/*Music player demo*/
+#define LV_USE_DEMO_MUSIC 0
+#if LV_USE_DEMO_MUSIC
+    #define LV_DEMO_MUSIC_SQUARE    0
+    #define LV_DEMO_MUSIC_LANDSCAPE 0
+    #define LV_DEMO_MUSIC_ROUND     0
+    #define LV_DEMO_MUSIC_LARGE     0
+    #define LV_DEMO_MUSIC_AUTO_PLAY 0
+#endif
+
+/*--END OF LV_CONF_H--*/
+
+#endif /*LV_CONF_H*/
+
+#endif /*End of "Content enable"*/

--- a/src/lv_conf_8.h
+++ b/src/lv_conf_8.h
@@ -438,7 +438,7 @@
  *Depends on LV_TXT_LINE_BREAK_LONG_LEN.*/
 #define LV_TXT_LINE_BREAK_LONG_POST_MIN_LEN 3
 
-/*The control character to use for signalling text recoloring.*/
+/*The control character to use for signaling text recoloring.*/
 #define LV_TXT_COLOR_CMD "#"
 
 /*Support bidirectional texts. Allows mixing Left-to-Right and Right-to-Left texts.

--- a/src/lv_conf_9.h
+++ b/src/lv_conf_9.h
@@ -1,0 +1,973 @@
+/**
+ * @file lv_conf.h
+ * Configuration file for v9.0.1-dev
+ */
+
+/*
+ * Copy this file as `lv_conf.h`
+ * 1. simply next to the `lvgl` folder
+ * 2. or any other places and
+ *    - define `LV_CONF_INCLUDE_SIMPLE`
+ *    - add the path as include path
+ */
+
+/* clang-format off */
+#if 1 /*Set it to "1" to enable content*/
+
+#ifndef LV_CONF_H
+#define LV_CONF_H
+
+/*====================
+   COLOR SETTINGS
+ *====================*/
+
+/*Color depth: 8 (A8), 16 (RGB565), 24 (RGB888), 32 (XRGB8888)*/
+#define LV_COLOR_DEPTH 16
+
+/*=========================
+   STDLIB WRAPPER SETTINGS
+ *=========================*/
+
+/* Possible values
+ * - LV_STDLIB_BUILTIN:     LVGL's built in implementation
+ * - LV_STDLIB_CLIB:        Standard C functions, like malloc, strlen, etc
+ * - LV_STDLIB_MICROPYTHON: MicroPython implementation
+ * - LV_STDLIB_RTTHREAD:    RT-Thread implementation
+ * - LV_STDLIB_CUSTOM:      Implement the functions externally
+ */
+#define LV_USE_STDLIB_MALLOC    LV_STDLIB_BUILTIN
+#define LV_USE_STDLIB_STRING    LV_STDLIB_BUILTIN
+#define LV_USE_STDLIB_SPRINTF   LV_STDLIB_BUILTIN
+
+
+#if LV_USE_STDLIB_MALLOC == LV_STDLIB_BUILTIN
+    /*Size of the memory available for `lv_malloc()` in bytes (>= 2kB)*/
+    #define LV_MEM_SIZE (64 * 1024U)          /*[bytes]*/
+
+    /*Size of the memory expand for `lv_malloc()` in bytes*/
+    #define LV_MEM_POOL_EXPAND_SIZE 0
+
+    /*Set an address for the memory pool instead of allocating it as a normal array. Can be in external SRAM too.*/
+    #define LV_MEM_ADR 0     /*0: unused*/
+    /*Instead of an address give a memory allocator that will be called to get a memory pool for LVGL. E.g. my_malloc*/
+    #if LV_MEM_ADR == 0
+        #undef LV_MEM_POOL_INCLUDE
+        #undef LV_MEM_POOL_ALLOC
+    #endif
+#endif  /*LV_USE_MALLOC == LV_STDLIB_BUILTIN*/
+
+/*====================
+   HAL SETTINGS
+ *====================*/
+
+/*Default display refresh, input device read and animation step period.*/
+#define LV_DEF_REFR_PERIOD  33      /*[ms]*/
+
+/*Default Dot Per Inch. Used to initialize default sizes such as widgets sized, style paddings.
+ *(Not so important, you can adjust it to modify default sizes and spaces)*/
+#define LV_DPI_DEF 130     /*[px/inch]*/
+
+/*=================
+ * OPERATING SYSTEM
+ *=================*/
+/*Select an operating system to use. Possible options:
+ * - LV_OS_NONE
+ * - LV_OS_PTHREAD
+ * - LV_OS_FREERTOS
+ * - LV_OS_CMSIS_RTOS2
+ * - LV_OS_RTTHREAD
+ * - LV_OS_WINDOWS
+ * - LV_OS_CUSTOM */
+#define LV_USE_OS   LV_OS_NONE
+
+#if LV_USE_OS == LV_OS_CUSTOM
+    #define LV_OS_CUSTOM_INCLUDE <stdint.h>
+#endif
+
+/*========================
+ * RENDERING CONFIGURATION
+ *========================*/
+
+/*Align the stride of all layers and images to this bytes*/
+#define LV_DRAW_BUF_STRIDE_ALIGN                1
+
+/*Align the start address of draw_buf addresses to this bytes*/
+#define LV_DRAW_BUF_ALIGN                       4
+
+#define LV_USE_DRAW_SW 1
+#if LV_USE_DRAW_SW == 1
+    /* Set the number of draw unit.
+     * > 1 requires an operating system enabled in `LV_USE_OS`
+     * > 1 means multiply threads will render the screen in parallel */
+    #define LV_DRAW_SW_DRAW_UNIT_CNT    1
+
+    /* Use Arm-2D to accelerate the sw render */
+    #define LV_USE_DRAW_ARM2D_SYNC      1
+
+    /* If a widget has `style_opa < 255` (not `bg_opa`, `text_opa` etc) or not NORMAL blend mode
+     * it is buffered into a "simple" layer before rendering. The widget can be buffered in smaller chunks.
+     * "Transformed layers" (if `transform_angle/zoom` are set) use larger buffers
+     * and can't be drawn in chunks. */
+
+    /*The target buffer size for simple layer chunks.*/
+    #define LV_DRAW_SW_LAYER_SIMPLE_BUF_SIZE    (24 * 1024)   /*[bytes]*/
+
+    /* 0: use a simple renderer capable of drawing only simple rectangles with gradient, images, texts, and straight lines only
+     * 1: use a complex renderer capable of drawing rounded corners, shadow, skew lines, and arcs too */
+    #define LV_DRAW_SW_COMPLEX          1
+
+    #if LV_DRAW_SW_COMPLEX == 1
+        /*Allow buffering some shadow calculation.
+        *LV_DRAW_SW_SHADOW_CACHE_SIZE is the max. shadow size to buffer, where shadow size is `shadow_width + radius`
+        *Caching has LV_DRAW_SW_SHADOW_CACHE_SIZE^2 RAM cost*/
+        #define LV_DRAW_SW_SHADOW_CACHE_SIZE 0
+
+        /* Set number of maximally cached circle data.
+        * The circumference of 1/4 circle are saved for anti-aliasing
+        * radius * 4 bytes are used per circle (the most often used radiuses are saved)
+        * 0: to disable caching */
+        #define LV_DRAW_SW_CIRCLE_CACHE_SIZE 4
+    #endif
+
+    #define  LV_USE_DRAW_SW_ASM     LV_DRAW_SW_ASM_NONE
+
+    #if LV_USE_DRAW_SW_ASM == LV_DRAW_SW_ASM_CUSTOM
+        #define  LV_DRAW_SW_ASM_CUSTOM_INCLUDE ""
+    #endif
+#endif
+
+/* Use NXP's VG-Lite GPU on iMX RTxxx platforms. */
+#define LV_USE_DRAW_VGLITE 0
+
+#if LV_USE_DRAW_VGLITE
+    /* Enable blit quality degradation workaround recommended for screen's dimension > 352 pixels. */
+    #define LV_USE_VGLITE_BLIT_SPLIT 0
+
+    #if LV_USE_OS
+        /* Enable VGLite draw async. Queue multiple tasks and flash them once to the GPU. */
+        #define LV_USE_VGLITE_DRAW_ASYNC 1
+    #endif
+
+    /* Enable VGLite asserts. */
+    #define LV_USE_VGLITE_ASSERT 0
+#endif
+
+/* Use NXP's PXP on iMX RTxxx platforms. */
+#define LV_USE_DRAW_PXP 0
+
+#if LV_USE_DRAW_PXP
+    /* Enable PXP asserts. */
+    #define LV_USE_PXP_ASSERT 0
+#endif
+
+/* Use Renesas Dave2D on RA  platforms. */
+#define LV_USE_DRAW_DAVE2D 0
+
+/* Draw using cached SDL textures*/
+#define LV_USE_DRAW_SDL 0
+
+/* Use VG-Lite GPU. */
+#define LV_USE_DRAW_VG_LITE 0
+
+#if LV_USE_DRAW_VG_LITE
+/* Enable VG-Lite custom external 'gpu_init()' function */
+#define LV_VG_LITE_USE_GPU_INIT 0
+
+/* Enable VG-Lite assert. */
+#define LV_VG_LITE_USE_ASSERT 0
+
+/* VG-Lite flush commit trigger threshold. GPU will try to batch these many draw tasks. */
+#define LV_VG_LITE_FLUSH_MAX_COUNT 8
+
+/* Enable border to simulate shadow
+ * NOTE: which usually improves performance,
+ * but does not guarantee the same rendering quality as the software. */
+#define LV_VG_LITE_USE_BOX_SHADOW 0
+
+#endif
+
+/*=======================
+ * FEATURE CONFIGURATION
+ *=======================*/
+
+/*-------------
+ * Logging
+ *-----------*/
+
+/*Enable the log module*/
+#define LV_USE_LOG 0
+#if LV_USE_LOG
+
+    /*How important log should be added:
+    *LV_LOG_LEVEL_TRACE       A lot of logs to give detailed information
+    *LV_LOG_LEVEL_INFO        Log important events
+    *LV_LOG_LEVEL_WARN        Log if something unwanted happened but didn't cause a problem
+    *LV_LOG_LEVEL_ERROR       Only critical issue, when the system may fail
+    *LV_LOG_LEVEL_USER        Only logs added by the user
+    *LV_LOG_LEVEL_NONE        Do not log anything*/
+    #define LV_LOG_LEVEL LV_LOG_LEVEL_WARN
+
+    /*1: Print the log with 'printf';
+    *0: User need to register a callback with `lv_log_register_print_cb()`*/
+    #define LV_LOG_PRINTF 0
+
+    /*1: Enable print timestamp;
+     *0: Disable print timestamp*/
+    #define LV_LOG_USE_TIMESTAMP 1
+
+    /*1: Print file and line number of the log;
+     *0: Do not print file and line number of the log*/
+    #define LV_LOG_USE_FILE_LINE 1
+
+    /*Enable/disable LV_LOG_TRACE in modules that produces a huge number of logs*/
+    #define LV_LOG_TRACE_MEM        1
+    #define LV_LOG_TRACE_TIMER      1
+    #define LV_LOG_TRACE_INDEV      1
+    #define LV_LOG_TRACE_DISP_REFR  1
+    #define LV_LOG_TRACE_EVENT      1
+    #define LV_LOG_TRACE_OBJ_CREATE 1
+    #define LV_LOG_TRACE_LAYOUT     1
+    #define LV_LOG_TRACE_ANIM       1
+    #define LV_LOG_TRACE_CACHE      1
+
+#endif  /*LV_USE_LOG*/
+
+/*-------------
+ * Asserts
+ *-----------*/
+
+/*Enable asserts if an operation is failed or an invalid data is found.
+ *If LV_USE_LOG is enabled an error message will be printed on failure*/
+#define LV_USE_ASSERT_NULL          1   /*Check if the parameter is NULL. (Very fast, recommended)*/
+#define LV_USE_ASSERT_MALLOC        1   /*Checks is the memory is successfully allocated or no. (Very fast, recommended)*/
+#define LV_USE_ASSERT_STYLE         0   /*Check if the styles are properly initialized. (Very fast, recommended)*/
+#define LV_USE_ASSERT_MEM_INTEGRITY 0   /*Check the integrity of `lv_mem` after critical operations. (Slow)*/
+#define LV_USE_ASSERT_OBJ           0   /*Check the object's type and existence (e.g. not deleted). (Slow)*/
+
+/*Add a custom handler when assert happens e.g. to restart the MCU*/
+#define LV_ASSERT_HANDLER_INCLUDE <stdint.h>
+#define LV_ASSERT_HANDLER while(1);   /*Halt by default*/
+
+/*-------------
+ * Debug
+ *-----------*/
+
+/*1: Draw random colored rectangles over the redrawn areas*/
+#define LV_USE_REFR_DEBUG 0
+
+/*1: Draw a red overlay for ARGB layers and a green overlay for RGB layers*/
+#define LV_USE_LAYER_DEBUG 0
+
+/*1: Draw overlays with different colors for each draw_unit's tasks.
+ *Also add the index number of the draw unit on white background.
+ *For layers add the index number of the draw unit on black background.*/
+#define LV_USE_PARALLEL_DRAW_DEBUG 0
+
+/*-------------
+ * Others
+ *-----------*/
+
+#define LV_ENABLE_GLOBAL_CUSTOM 0
+#if LV_ENABLE_GLOBAL_CUSTOM
+    /*Header to include for the custom 'lv_global' function"*/
+    #define LV_GLOBAL_CUSTOM_INCLUDE <stdint.h>
+#endif
+
+/*Default cache size in bytes.
+ *Used by image decoders such as `lv_lodepng` to keep the decoded image in the memory.
+ *If size is not set to 0, the decoder will fail to decode when the cache is full.
+ *If size is 0, the cache function is not enabled and the decoded mem will be released immediately after use.*/
+#define LV_CACHE_DEF_SIZE       0
+
+/*Default number of image header cache entries. The cache is used to store the headers of images
+ *The main logic is like `LV_CACHE_DEF_SIZE` but for image headers.*/
+#define LV_IMAGE_HEADER_CACHE_DEF_CNT 0
+
+/*Number of stops allowed per gradient. Increase this to allow more stops.
+ *This adds (sizeof(lv_color_t) + 1) bytes per additional stop*/
+#define LV_GRADIENT_MAX_STOPS   2
+
+/* Adjust color mix functions rounding. GPUs might calculate color mix (blending) differently.
+ * 0: round down, 64: round up from x.75, 128: round up from half, 192: round up from x.25, 254: round up */
+#define LV_COLOR_MIX_ROUND_OFS  0
+
+/* Add 2 x 32 bit variables to each lv_obj_t to speed up getting style properties */
+#define LV_OBJ_STYLE_CACHE      0
+
+/* Add `id` field to `lv_obj_t` */
+#define LV_USE_OBJ_ID           0
+
+/* Use lvgl builtin method for obj ID */
+#define LV_USE_OBJ_ID_BUILTIN   0
+
+/*Use obj property set/get API*/
+#define LV_USE_OBJ_PROPERTY 0
+
+/* VG-Lite Simulator */
+/*Requires: LV_USE_THORVG_INTERNAL or LV_USE_THORVG_EXTERNAL */
+#define LV_USE_VG_LITE_THORVG  0
+
+#if LV_USE_VG_LITE_THORVG
+
+    /*Enable LVGL's blend mode support*/
+    #define LV_VG_LITE_THORVG_LVGL_BLEND_SUPPORT 0
+
+    /*Enable YUV color format support*/
+    #define LV_VG_LITE_THORVG_YUV_SUPPORT 0
+
+    /*Enable 16 pixels alignment*/
+    #define LV_VG_LITE_THORVG_16PIXELS_ALIGN 1
+
+    /*Enable multi-thread render*/
+    #define LV_VG_LITE_THORVG_THREAD_RENDER 0
+
+#endif
+
+/*=====================
+ *  COMPILER SETTINGS
+ *====================*/
+
+/*For big endian systems set to 1*/
+#define LV_BIG_ENDIAN_SYSTEM 0
+
+/*Define a custom attribute to `lv_tick_inc` function*/
+#define LV_ATTRIBUTE_TICK_INC
+
+/*Define a custom attribute to `lv_timer_handler` function*/
+#define LV_ATTRIBUTE_TIMER_HANDLER
+
+/*Define a custom attribute to `lv_display_flush_ready` function*/
+#define LV_ATTRIBUTE_FLUSH_READY
+
+/*Required alignment size for buffers*/
+#define LV_ATTRIBUTE_MEM_ALIGN_SIZE 1
+
+/*Will be added where memories needs to be aligned (with -Os data might not be aligned to boundary by default).
+ * E.g. __attribute__((aligned(4)))*/
+#define LV_ATTRIBUTE_MEM_ALIGN
+
+/*Attribute to mark large constant arrays for example font's bitmaps*/
+#define LV_ATTRIBUTE_LARGE_CONST
+
+/*Compiler prefix for a big array declaration in RAM*/
+#define LV_ATTRIBUTE_LARGE_RAM_ARRAY
+
+/*Place performance critical functions into a faster memory (e.g RAM)*/
+#define LV_ATTRIBUTE_FAST_MEM
+
+/*Export integer constant to binding. This macro is used with constants in the form of LV_<CONST> that
+ *should also appear on LVGL binding API such as Micropython.*/
+#define LV_EXPORT_CONST_INT(int_value) struct _silence_gcc_warning /*The default value just prevents GCC warning*/
+
+/*Prefix all global extern data with this*/
+#define LV_ATTRIBUTE_EXTERN_DATA
+
+/* Use `float` as `lv_value_precise_t` */
+#define LV_USE_FLOAT            0
+
+/*==================
+ *   FONT USAGE
+ *===================*/
+
+/*Montserrat fonts with ASCII range and some symbols using bpp = 4
+ *https://fonts.google.com/specimen/Montserrat*/
+#define LV_FONT_MONTSERRAT_8  0
+#define LV_FONT_MONTSERRAT_10 0
+#define LV_FONT_MONTSERRAT_12 0
+#define LV_FONT_MONTSERRAT_14 1
+#define LV_FONT_MONTSERRAT_16 0
+#define LV_FONT_MONTSERRAT_18 0
+#define LV_FONT_MONTSERRAT_20 0
+#define LV_FONT_MONTSERRAT_22 0
+#define LV_FONT_MONTSERRAT_24 0
+#define LV_FONT_MONTSERRAT_26 0
+#define LV_FONT_MONTSERRAT_28 0
+#define LV_FONT_MONTSERRAT_30 0
+#define LV_FONT_MONTSERRAT_32 0
+#define LV_FONT_MONTSERRAT_34 0
+#define LV_FONT_MONTSERRAT_36 0
+#define LV_FONT_MONTSERRAT_38 0
+#define LV_FONT_MONTSERRAT_40 0
+#define LV_FONT_MONTSERRAT_42 0
+#define LV_FONT_MONTSERRAT_44 0
+#define LV_FONT_MONTSERRAT_46 0
+#define LV_FONT_MONTSERRAT_48 0
+
+/*Demonstrate special features*/
+#define LV_FONT_MONTSERRAT_28_COMPRESSED 0  /*bpp = 3*/
+#define LV_FONT_DEJAVU_16_PERSIAN_HEBREW 0  /*Hebrew, Arabic, Persian letters and all their forms*/
+#define LV_FONT_SIMSUN_16_CJK            0  /*1000 most common CJK radicals*/
+
+/*Pixel perfect monospace fonts*/
+#define LV_FONT_UNSCII_8  0
+#define LV_FONT_UNSCII_16 0
+
+/*Optionally declare custom fonts here.
+ *You can use these fonts as default font too and they will be available globally.
+ *E.g. #define LV_FONT_CUSTOM_DECLARE   LV_FONT_DECLARE(my_font_1) LV_FONT_DECLARE(my_font_2)*/
+#define LV_FONT_CUSTOM_DECLARE
+
+/*Always set a default font*/
+#define LV_FONT_DEFAULT &lv_font_montserrat_14
+
+/*Enable handling large font and/or fonts with a lot of characters.
+ *The limit depends on the font size, font face and bpp.
+ *Compiler error will be triggered if a font needs it.*/
+#define LV_FONT_FMT_TXT_LARGE 0
+
+/*Enables/disables support for compressed fonts.*/
+#define LV_USE_FONT_COMPRESSED 0
+
+/*Enable drawing placeholders when glyph dsc is not found*/
+#define LV_USE_FONT_PLACEHOLDER 1
+
+/*=================
+ *  TEXT SETTINGS
+ *=================*/
+
+/**
+ * Select a character encoding for strings.
+ * Your IDE or editor should have the same character encoding
+ * - LV_TXT_ENC_UTF8
+ * - LV_TXT_ENC_ASCII
+ */
+#define LV_TXT_ENC LV_TXT_ENC_UTF8
+
+/*Can break (wrap) texts on these chars*/
+#define LV_TXT_BREAK_CHARS " ,.;:-_)]}"
+
+/*If a word is at least this long, will break wherever "prettiest"
+ *To disable, set to a value <= 0*/
+#define LV_TXT_LINE_BREAK_LONG_LEN 0
+
+/*Minimum number of characters in a long word to put on a line before a break.
+ *Depends on LV_TXT_LINE_BREAK_LONG_LEN.*/
+#define LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN 3
+
+/*Minimum number of characters in a long word to put on a line after a break.
+ *Depends on LV_TXT_LINE_BREAK_LONG_LEN.*/
+#define LV_TXT_LINE_BREAK_LONG_POST_MIN_LEN 3
+
+/*Support bidirectional texts. Allows mixing Left-to-Right and Right-to-Left texts.
+ *The direction will be processed according to the Unicode Bidirectional Algorithm:
+ *https://www.w3.org/International/articles/inline-bidi-markup/uba-basics*/
+#define LV_USE_BIDI 0
+#if LV_USE_BIDI
+    /*Set the default direction. Supported values:
+    *`LV_BASE_DIR_LTR` Left-to-Right
+    *`LV_BASE_DIR_RTL` Right-to-Left
+    *`LV_BASE_DIR_AUTO` detect texts base direction*/
+    #define LV_BIDI_BASE_DIR_DEF LV_BASE_DIR_AUTO
+#endif
+
+/*Enable Arabic/Persian processing
+ *In these languages characters should be replaced with an other form based on their position in the text*/
+#define LV_USE_ARABIC_PERSIAN_CHARS 0
+
+/*==================
+ * WIDGETS
+ *================*/
+
+/*Documentation of the widgets: https://docs.lvgl.io/latest/en/html/widgets/index.html*/
+
+#define LV_WIDGETS_HAS_DEFAULT_VALUE  1
+
+#define LV_USE_ANIMIMG    1
+
+#define LV_USE_ARC        1
+
+#define LV_USE_BAR        1
+
+#define LV_USE_BUTTON        1
+
+#define LV_USE_BUTTONMATRIX  1
+
+#define LV_USE_CALENDAR   1
+#if LV_USE_CALENDAR
+    #define LV_CALENDAR_WEEK_STARTS_MONDAY 0
+    #if LV_CALENDAR_WEEK_STARTS_MONDAY
+        #define LV_CALENDAR_DEFAULT_DAY_NAMES {"Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"}
+    #else
+        #define LV_CALENDAR_DEFAULT_DAY_NAMES {"Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"}
+    #endif
+
+    #define LV_CALENDAR_DEFAULT_MONTH_NAMES {"January", "February", "March",  "April", "May",  "June", "July", "August", "September", "October", "November", "December"}
+    #define LV_USE_CALENDAR_HEADER_ARROW 1
+    #define LV_USE_CALENDAR_HEADER_DROPDOWN 1
+#endif  /*LV_USE_CALENDAR*/
+
+#define LV_USE_CANVAS     1
+
+#define LV_USE_CHART      1
+
+#define LV_USE_CHECKBOX   1
+
+#define LV_USE_DROPDOWN   1   /*Requires: lv_label*/
+
+#define LV_USE_IMAGE      1   /*Requires: lv_label*/
+
+#define LV_USE_IMAGEBUTTON     1
+
+#define LV_USE_KEYBOARD   1
+
+#define LV_USE_LABEL      1
+#if LV_USE_LABEL
+    #define LV_LABEL_TEXT_SELECTION 1 /*Enable selecting text of the label*/
+    #define LV_LABEL_LONG_TXT_HINT 1  /*Store some extra info in labels to speed up drawing of very long texts*/
+    #define LV_LABEL_WAIT_CHAR_COUNT 3  /*The count of wait chart*/
+#endif
+
+#define LV_USE_LED        1
+
+#define LV_USE_LINE       1
+
+#define LV_USE_LIST       1
+
+#define LV_USE_MENU       1
+
+#define LV_USE_MSGBOX     1
+
+#define LV_USE_ROLLER     1   /*Requires: lv_label*/
+
+#define LV_USE_SCALE      1
+
+#define LV_USE_SLIDER     1   /*Requires: lv_bar*/
+
+#define LV_USE_SPAN       1
+#if LV_USE_SPAN
+    /*A line text can contain maximum num of span descriptor */
+    #define LV_SPAN_SNIPPET_STACK_SIZE 64
+#endif
+
+#define LV_USE_SPINBOX    1
+
+#define LV_USE_SPINNER    1
+
+#define LV_USE_SWITCH     1
+
+#define LV_USE_TEXTAREA   1   /*Requires: lv_label*/
+#if LV_USE_TEXTAREA != 0
+    #define LV_TEXTAREA_DEF_PWD_SHOW_TIME 1500    /*ms*/
+#endif
+
+#define LV_USE_TABLE      1
+
+#define LV_USE_TABVIEW    1
+
+#define LV_USE_TILEVIEW   1
+
+#define LV_USE_WIN        1
+
+/*==================
+ * THEMES
+ *==================*/
+
+/*A simple, impressive and very complete theme*/
+#define LV_USE_THEME_DEFAULT 1
+#if LV_USE_THEME_DEFAULT
+
+    /*0: Light mode; 1: Dark mode*/
+    #define LV_THEME_DEFAULT_DARK 0
+
+    /*1: Enable grow on press*/
+    #define LV_THEME_DEFAULT_GROW 1
+
+    /*Default transition time in [ms]*/
+    #define LV_THEME_DEFAULT_TRANSITION_TIME 80
+#endif /*LV_USE_THEME_DEFAULT*/
+
+/*A very simple theme that is a good starting point for a custom theme*/
+#define LV_USE_THEME_SIMPLE 1
+
+/*A theme designed for monochrome displays*/
+#define LV_USE_THEME_MONO 1
+
+/*==================
+ * LAYOUTS
+ *==================*/
+
+/*A layout similar to Flexbox in CSS.*/
+#define LV_USE_FLEX 1
+
+/*A layout similar to Grid in CSS.*/
+#define LV_USE_GRID 1
+
+/*====================
+ * 3RD PARTS LIBRARIES
+ *====================*/
+
+/*File system interfaces for common APIs */
+
+/*API for fopen, fread, etc*/
+#define LV_USE_FS_STDIO 0
+#if LV_USE_FS_STDIO
+    #define LV_FS_STDIO_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+    #define LV_FS_STDIO_PATH ""         /*Set the working directory. File/directory paths will be appended to it.*/
+    #define LV_FS_STDIO_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
+#endif
+
+/*API for open, read, etc*/
+#define LV_USE_FS_POSIX 0
+#if LV_USE_FS_POSIX
+    #define LV_FS_POSIX_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+    #define LV_FS_POSIX_PATH ""         /*Set the working directory. File/directory paths will be appended to it.*/
+    #define LV_FS_POSIX_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
+#endif
+
+/*API for CreateFile, ReadFile, etc*/
+#define LV_USE_FS_WIN32 0
+#if LV_USE_FS_WIN32
+    #define LV_FS_WIN32_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+    #define LV_FS_WIN32_PATH ""         /*Set the working directory. File/directory paths will be appended to it.*/
+    #define LV_FS_WIN32_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
+#endif
+
+/*API for FATFS (needs to be added separately). Uses f_open, f_read, etc*/
+#define LV_USE_FS_FATFS 0
+#if LV_USE_FS_FATFS
+    #define LV_FS_FATFS_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+    #define LV_FS_FATFS_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
+#endif
+
+/*API for memory-mapped file access. */
+#define LV_USE_FS_MEMFS 0
+#if LV_USE_FS_MEMFS
+    #define LV_FS_MEMFS_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+#endif
+
+/*LODEPNG decoder library*/
+#define LV_USE_LODEPNG 0
+
+/*PNG decoder(libpng) library*/
+#define LV_USE_LIBPNG 0
+
+/*BMP decoder library*/
+#define LV_USE_BMP 0
+
+/* JPG + split JPG decoder library.
+ * Split JPG is a custom format optimized for embedded systems. */
+#define LV_USE_TJPGD 0
+
+/* libjpeg-turbo decoder library.
+ * Supports complete JPEG specifications and high-performance JPEG decoding. */
+#define LV_USE_LIBJPEG_TURBO 0
+
+/*GIF decoder library*/
+#define LV_USE_GIF 0
+#if LV_USE_GIF
+/*GIF decoder accelerate*/
+#define LV_GIF_CACHE_DECODE_DATA 0
+#endif
+
+
+/*Decode bin images to RAM*/
+#define LV_BIN_DECODER_RAM_LOAD 0
+
+/*RLE decompress library*/
+#define LV_USE_RLE 0
+
+/*QR code library*/
+#define LV_USE_QRCODE 0
+
+/*Barcode code library*/
+#define LV_USE_BARCODE 0
+
+/*FreeType library*/
+#define LV_USE_FREETYPE 0
+#if LV_USE_FREETYPE
+    /*Memory used by FreeType to cache characters in kilobytes*/
+    #define LV_FREETYPE_CACHE_SIZE 768
+
+    /*Let FreeType to use LVGL memory and file porting*/
+    #define LV_FREETYPE_USE_LVGL_PORT 0
+
+    /* Maximum number of opened FT_Face/FT_Size objects managed by this cache instance. */
+    /* (0:use system defaults) */
+    #define LV_FREETYPE_CACHE_FT_FACES 8
+    #define LV_FREETYPE_CACHE_FT_SIZES 8
+    #define LV_FREETYPE_CACHE_FT_GLYPH_CNT 256
+#endif
+
+/* Built-in TTF decoder */
+#define LV_USE_TINY_TTF 0
+#if LV_USE_TINY_TTF
+    /* Enable loading TTF data from files */
+    #define LV_TINY_TTF_FILE_SUPPORT 0
+#endif
+
+/*Rlottie library*/
+#define LV_USE_RLOTTIE 0
+
+/*Enable Vector Graphic APIs*/
+#define LV_USE_VECTOR_GRAPHIC  0
+
+/* Enable ThorVG (vector graphics library) from the src/libs folder */
+#define LV_USE_THORVG_INTERNAL 0
+
+/* Enable ThorVG by assuming that its installed and linked to the project */
+#define LV_USE_THORVG_EXTERNAL 0
+
+/*Enable LZ4 compress/decompress lib*/
+#define LV_USE_LZ4  0
+
+/*Use lvgl built-in LZ4 lib*/
+#define LV_USE_LZ4_INTERNAL  0
+
+/*Use external LZ4 library*/
+#define LV_USE_LZ4_EXTERNAL  0
+
+/*FFmpeg library for image decoding and playing videos
+ *Supports all major image formats so do not enable other image decoder with it*/
+#define LV_USE_FFMPEG 0
+#if LV_USE_FFMPEG
+    /*Dump input information to stderr*/
+    #define LV_FFMPEG_DUMP_FORMAT 0
+#endif
+
+/*==================
+ * OTHERS
+ *==================*/
+
+/*1: Enable API to take snapshot for object*/
+#define LV_USE_SNAPSHOT 0
+
+/*1: Enable system monitor component*/
+#define LV_USE_SYSMON   0
+#if LV_USE_SYSMON
+    /*Get the idle percentage. E.g. uint32_t my_get_idle(void);*/
+    #define LV_SYSMON_GET_IDLE lv_timer_get_idle
+
+    /*1: Show CPU usage and FPS count
+     * Requires `LV_USE_SYSMON = 1`*/
+    #define LV_USE_PERF_MONITOR 0
+    #if LV_USE_PERF_MONITOR
+        #define LV_USE_PERF_MONITOR_POS LV_ALIGN_BOTTOM_RIGHT
+
+        /*0: Displays performance data on the screen, 1: Prints performance data using log.*/
+        #define LV_USE_PERF_MONITOR_LOG_MODE 0
+    #endif
+
+    /*1: Show the used memory and the memory fragmentation
+     * Requires `LV_USE_BUILTIN_MALLOC = 1`
+     * Requires `LV_USE_SYSMON = 1`*/
+    #define LV_USE_MEM_MONITOR 0
+    #if LV_USE_MEM_MONITOR
+        #define LV_USE_MEM_MONITOR_POS LV_ALIGN_BOTTOM_LEFT
+    #endif
+
+#endif /*LV_USE_SYSMON*/
+
+/*1: Enable the runtime performance profiler*/
+#define LV_USE_PROFILER 0
+#if LV_USE_PROFILER
+    /*1: Enable the built-in profiler*/
+    #define LV_USE_PROFILER_BUILTIN 1
+    #if LV_USE_PROFILER_BUILTIN
+        /*Default profiler trace buffer size*/
+        #define LV_PROFILER_BUILTIN_BUF_SIZE (16 * 1024)     /*[bytes]*/
+    #endif
+
+    /*Header to include for the profiler*/
+    #define LV_PROFILER_INCLUDE "lvgl/src/misc/lv_profiler_builtin.h"
+
+    /*Profiler start point function*/
+    #define LV_PROFILER_BEGIN    LV_PROFILER_BUILTIN_BEGIN
+
+    /*Profiler end point function*/
+    #define LV_PROFILER_END      LV_PROFILER_BUILTIN_END
+
+    /*Profiler start point function with custom tag*/
+    #define LV_PROFILER_BEGIN_TAG LV_PROFILER_BUILTIN_BEGIN_TAG
+
+    /*Profiler end point function with custom tag*/
+    #define LV_PROFILER_END_TAG   LV_PROFILER_BUILTIN_END_TAG
+#endif
+
+/*1: Enable Monkey test*/
+#define LV_USE_MONKEY 0
+
+/*1: Enable grid navigation*/
+#define LV_USE_GRIDNAV 0
+
+/*1: Enable lv_obj fragment*/
+#define LV_USE_FRAGMENT 0
+
+/*1: Support using images as font in label or span widgets */
+#define LV_USE_IMGFONT 0
+
+/*1: Enable an observer pattern implementation*/
+#define LV_USE_OBSERVER 1
+
+/*1: Enable Pinyin input method*/
+/*Requires: lv_keyboard*/
+#define LV_USE_IME_PINYIN 0
+#if LV_USE_IME_PINYIN
+    /*1: Use default thesaurus*/
+    /*If you do not use the default thesaurus, be sure to use `lv_ime_pinyin` after setting the thesauruss*/
+    #define LV_IME_PINYIN_USE_DEFAULT_DICT 1
+    /*Set the maximum number of candidate panels that can be displayed*/
+    /*This needs to be adjusted according to the size of the screen*/
+    #define LV_IME_PINYIN_CAND_TEXT_NUM 6
+
+    /*Use 9 key input(k9)*/
+    #define LV_IME_PINYIN_USE_K9_MODE      1
+    #if LV_IME_PINYIN_USE_K9_MODE == 1
+        #define LV_IME_PINYIN_K9_CAND_TEXT_NUM 3
+    #endif /*LV_IME_PINYIN_USE_K9_MODE*/
+#endif
+
+/*1: Enable file explorer*/
+/*Requires: lv_table*/
+#define LV_USE_FILE_EXPLORER                     0
+#if LV_USE_FILE_EXPLORER
+    /*Maximum length of path*/
+    #define LV_FILE_EXPLORER_PATH_MAX_LEN        (128)
+    /*Quick access bar, 1:use, 0:not use*/
+    /*Requires: lv_list*/
+    #define LV_FILE_EXPLORER_QUICK_ACCESS        1
+#endif
+
+/*==================
+ * DEVICES
+ *==================*/
+
+/*Use SDL to open window on PC and handle mouse and keyboard*/
+#define LV_USE_SDL              0
+#if LV_USE_SDL
+    #define LV_SDL_INCLUDE_PATH    <SDL2/SDL.h>
+    #define LV_SDL_RENDER_MODE     LV_DISPLAY_RENDER_MODE_DIRECT   /*LV_DISPLAY_RENDER_MODE_DIRECT is recommended for best performance*/
+    #define LV_SDL_BUF_COUNT       1    /*1 or 2*/
+    #define LV_SDL_FULLSCREEN      0    /*1: Make the window full screen by default*/
+    #define LV_SDL_DIRECT_EXIT     1    /*1: Exit the application when all SDL windows are closed*/
+#endif
+
+/*Use X11 to open window on Linux desktop and handle mouse and keyboard*/
+#define LV_USE_X11              0
+#if LV_USE_X11
+    #define LV_X11_DIRECT_EXIT         1  /*Exit the application when all X11 windows have been closed*/
+    #define LV_X11_DOUBLE_BUFFER       1  /*Use double buffers for endering*/
+    /*select only 1 of the following render modes (LV_X11_RENDER_MODE_PARTIAL preferred!)*/
+    #define LV_X11_RENDER_MODE_PARTIAL 1  /*Partial render mode (preferred)*/
+    #define LV_X11_RENDER_MODE_DIRECT  0  /*direct render mode*/
+    #define LV_X11_RENDER_MODE_FULL    0  /*Full render mode*/
+#endif
+
+/*Driver for /dev/fb*/
+#define LV_USE_LINUX_FBDEV      0
+#if LV_USE_LINUX_FBDEV
+    #define LV_LINUX_FBDEV_BSD           0
+    #define LV_LINUX_FBDEV_RENDER_MODE   LV_DISPLAY_RENDER_MODE_PARTIAL
+    #define LV_LINUX_FBDEV_BUFFER_COUNT  0
+    #define LV_LINUX_FBDEV_BUFFER_SIZE   60
+#endif
+
+/*Use Nuttx to open window and handle touchscreen*/
+#define LV_USE_NUTTX    0
+
+#if LV_USE_NUTTX
+    #define LV_USE_NUTTX_LIBUV    0
+
+    /*Use Nuttx custom init API to open window and handle touchscreen*/
+    #define LV_USE_NUTTX_CUSTOM_INIT    0
+
+    /*Driver for /dev/lcd*/
+    #define LV_USE_NUTTX_LCD      0
+    #if LV_USE_NUTTX_LCD
+        #define LV_NUTTX_LCD_BUFFER_COUNT    0
+        #define LV_NUTTX_LCD_BUFFER_SIZE     60
+    #endif
+
+    /*Driver for /dev/input*/
+    #define LV_USE_NUTTX_TOUCHSCREEN    0
+
+#endif
+
+/*Driver for /dev/dri/card*/
+#define LV_USE_LINUX_DRM        0
+
+/*Interface for TFT_eSPI*/
+#define LV_USE_TFT_ESPI         0
+
+/*Driver for evdev input devices*/
+#define LV_USE_EVDEV    0
+
+/*Driver for libinput input devices*/
+#define LV_USE_LIBINPUT    0
+
+#if LV_USE_LIBINPUT
+    #define LV_LIBINPUT_BSD    0
+
+    /*Full keyboard support*/
+    #define LV_LIBINPUT_XKB             0
+    #if LV_LIBINPUT_XKB
+        /*"setxkbmap -query" can help find the right values for your keyboard*/
+        #define LV_LIBINPUT_XKB_KEY_MAP { .rules = NULL, .model = "pc101", .layout = "us", .variant = NULL, .options = NULL }
+    #endif
+#endif
+
+/*Drivers for LCD devices connected via SPI/parallel port*/
+#define LV_USE_ST7735		0
+#define LV_USE_ST7789		0
+#define LV_USE_ST7796		0
+#define LV_USE_ILI9341		0
+
+#define LV_USE_GENERIC_MIPI (LV_USE_ST7735 | LV_USE_ST7789 | LV_USE_ST7796 | LV_USE_ILI9341)
+
+/* LVGL Windows backend */
+#define LV_USE_WINDOWS    0
+
+/*==================
+* EXAMPLES
+*==================*/
+
+/*Enable the examples to be built with the library*/
+#define LV_BUILD_EXAMPLES 1
+
+/*===================
+ * DEMO USAGE
+ ====================*/
+
+/*Show some widget. It might be required to increase `LV_MEM_SIZE` */
+#define LV_USE_DEMO_WIDGETS 0
+
+/*Demonstrate the usage of encoder and keyboard*/
+#define LV_USE_DEMO_KEYPAD_AND_ENCODER 0
+
+/*Benchmark your system*/
+#define LV_USE_DEMO_BENCHMARK 0
+
+/*Render test for each primitives. Requires at least 480x272 display*/
+#define LV_USE_DEMO_RENDER 0
+
+/*Stress test for LVGL*/
+#define LV_USE_DEMO_STRESS 0
+
+/*Music player demo*/
+#define LV_USE_DEMO_MUSIC 0
+#if LV_USE_DEMO_MUSIC
+    #define LV_DEMO_MUSIC_SQUARE    0
+    #define LV_DEMO_MUSIC_LANDSCAPE 0
+    #define LV_DEMO_MUSIC_ROUND     0
+    #define LV_DEMO_MUSIC_LARGE     0
+    #define LV_DEMO_MUSIC_AUTO_PLAY 0
+#endif
+
+/*Flex layout demo*/
+#define LV_USE_DEMO_FLEX_LAYOUT     0
+
+/*Smart-phone like multi-language demo*/
+#define LV_USE_DEMO_MULTILANG       0
+
+/*Widget transformation demo*/
+#define LV_USE_DEMO_TRANSFORM       0
+
+/*Demonstrate scroll settings*/
+#define LV_USE_DEMO_SCROLL          0
+
+/*Vector graphic demo*/
+#define LV_USE_DEMO_VECTOR_GRAPHIC  0
+/*--END OF LV_CONF_H--*/
+
+#endif /*LV_CONF_H*/
+
+#endif /*End of "Content enable"*/


### PR DESCRIPTION
Modifications made so can be used with the GigaDisplay whether using Zephyr or mbed. 

The changes made for zephyr imply that Arduino_h7_portenta is no longer needed to run the display and gfx as well as the camera - does not support UVC.

In addition as mentioned [here ](https://github.com/arduino/ArduinoCore-zephyr/issues/92#issuecomment-3150223321) 

> certain sketches will not work in the GigaDisplay library since they have not been implemented in the core:
> 
> 1. lvgl - not implemented
> 2. display camera - although I can modify that one to just use the GC2145. Multiple cameras are no longer supported > like they were in mbed
> 3. microphone - not implemented yet

Not sure if everyone prefers if they are deleted or just left as place holders?

@KurtE and I have been using the library since we created it.

Readme will probably have to be updated at some point.  Would consider this first release
